### PR TITLE
Use latitude dependent salinity surface boundary and initial condition

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GyreInABox = "d40f67ff-4a83-48da-8213-065d3ac3739e"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -92,30 +92,33 @@ save("initial_temperature_and_salinity.svg", figure)
 
 The below example illustrates setting up and running a simulation of the model with the
 default parameter values, and default configuration modulo reduction of the spatial
-resolution to $60\times 60 \times 25$, the simulation time to 6 hours and changing
-the model to record only a depth slice along longitude axis as outputs. The resulting
-depth slices of simulated fields are recorded as an animation using CairoMakie. The
-simulation time here is too short for the simulated fields to show any interesting
-behaviour, with this example just meant to illustrate the overall workflow while
-remaining relatively cheap to run.
+resolution to $60\times 60 \times 25$, the simulation time to 6 hours and changing the
+model to record only a horizontal (surface) slice and depth slice along longitude axis
+as outputs. The resulting horizontal and depth slices of simulated fields are recorded
+as an animation using CairoMakie. The simulation time here is too short for the
+simulated fields to show any interesting behaviour, with this example just meant to
+illustrate the overall workflow while remaining relatively cheap to run.
 
 ```@example
 using Oceananigans.Units
 using GyreInABox
 
 parameters = GyreInABoxParameters()
-output_type = LongitudeDepthSlice()
+output_types = (LongitudeDepthSlice(), HorizontalSlice())
 configuration = GyreInABoxConfiguration(
     grid_size=(60, 60, 25),
-    simulation_time=6hour,
-    output_types=(output_type,)
+    simulation_time=1day,
+    output_types=output_types
 )
 run_simulation(parameters, configuration)
-record_animation(configuration, output_type)
+for output_type in output_types
+    record_animation(configuration, output_type)
+end
 nothing # hide
 ```
 
-![Example simulated output](gyre_model_longitude_depth_slice.mp4)
+![Example simulated output (longitude-depth slice)](gyre_model_longitude_depth_slice.mp4)
+![Example simulated output (horizontal slice)](gyre_model_horizontal_slice.mp4)
 
 ## API reference
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,6 +6,86 @@ CurrentModule = GyreInABox
 
 Documentation for [GyreInABox](https://github.com/aria-verify/GyreInABox.jl).
 
+## Model details
+
+The model is an adaptation of the [baroclinic gyre example](https://mitgcm.readthedocs.io/en/latest/examples/baroclinic_gyre/baroclinic_gyre.html)
+from the MITgcm documentation. It simulates a wind and buoyancy forced double-gyre
+ocean circulation on a spherical shell sector spatial domain, with default domain extents
+$(0^\circ, 60^\circ) \times (15^\circ, 75^\circ) \times (-1800\textsf{m}, 0\textsf{m})$
+(longitude × latitude × depth dimensions).
+
+By default a non-linear TEOS-10 polynomial equation of state is used to compute buoyancy
+from salinity and temperature fields. No slip / no-flux boundary conditions are
+applied to the velocity fields on all walls, and a boundary condition corresponding to
+a damping zonal drag on the bottom surface. The zonal velocity component is subject to a
+latitude dependent wind stress roughly reflecting average zonal wind patterns at the surface.
+The temperature and salinity fields have no-flux boundary conditions applied on all walls
+and the bottom surface, and relaxation boundary conditions on the top surface which restore
+the surface fields towards a latitude dependent reference temperature / salinity with a
+parameterised relaxation time. The surface wind stress, reference temperature and reference
+salinity as a function of latitude are shown in the figure below.
+
+```@setup model_details
+using GyreInABox
+using CairoMakie
+using Oceananigans
+
+parameters = GyreInABoxParameters()
+configuration = GyreInABoxConfiguration()
+
+grid = GyreInABox.setup_grid(configuration)
+
+λ, φ, z = nodes(grid, Center(), Center(), Center())
+
+wind_stress = GyreInABox.zonal_wind_stress.(Nothing, φ, Nothing, (parameters,))
+reference_temperature =  GyreInABox.reference_surface_temperature.(φ, (parameters,))
+reference_salinity =  GyreInABox.reference_surface_salinity.(φ, (parameters,))
+
+figure = Figure(size=(800, 200))
+
+ylabel = "Latitude φ / °"
+
+axis_wind_stress = Axis(figure[1, 1]; ylabel, xlabel="Zonal wind stress / 10⁻³ m² s⁻²")
+axis_temperature = Axis(figure[1, 2]; ylabel, xlabel="Reference temperature / °C")
+axis_salinity = Axis(figure[1, 3]; ylabel, xlabel="Reference salinity /  g kg⁻¹")
+
+# Due to Oceananigans' flux convention, positive zonal wind stress flux at top surface
+# boundary produces currents in negative (zonal) direction and vice versa therefore
+# negate wind stress profile to better match visual intuition
+lines!(axis_wind_stress, -wind_stress * 10^3, φ)
+lines!(axis_temperature, reference_temperature, φ)
+lines!(axis_salinity, reference_salinity, φ)
+
+save("surface_forcings.svg", figure)
+```
+
+![Surface forcings for model](surface_forcings.svg)
+
+The model is initialised from rest (zero velocity). The temperature and salinity fields
+are initialised to match the reference temperature and salinity at the surface and
+following smoothly varying thermocline / halocline like profiles with depth, and
+constant in longitude, as shown in the figure below.
+
+```@setup model_details
+initial_temperature = GyreInABox.initial_temperature.(φ, z', (parameters,))
+initial_salinity = GyreInABox.initial_salinity.(φ, z', (parameters,))
+
+figure = Figure(size=(600, 300))
+
+xlabel = "Latitude φ / °"
+ylabel = "Depth / m"
+
+axis_temperature = Axis(figure[1, 1]; xlabel, ylabel)
+axis_salinity = Axis(figure[1, 2]; xlabel, ylabel)
+
+heatmap!(axis_temperature, φ, z, initial_temperature)
+heatmap!(axis_salinity, φ, z, initial_salinity)
+
+save("initial_temperature_and_salinity.svg", figure)
+```
+
+![Initial temperature and salinity fields for model](initial_temperature_and_salinity.svg)
+
 ## Usage example
 
 The below example illustrates setting up and running a simulation of the model with the

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -70,16 +70,18 @@ constant in longitude, as shown in the figure below.
 initial_temperature = GyreInABox.initial_temperature.(φ, z', (parameters,))
 initial_salinity = GyreInABox.initial_salinity.(φ, z', (parameters,))
 
-figure = Figure(size=(600, 300))
+figure = Figure(size=(800, 300))
 
 xlabel = "Latitude φ / °"
 ylabel = "Depth / m"
 
-axis_temperature = Axis(figure[1, 1]; xlabel, ylabel)
-axis_salinity = Axis(figure[1, 2]; xlabel, ylabel)
+axis_temperature = Axis(figure[1, 1]; xlabel, ylabel, title="Initial temperature")
+axis_salinity = Axis(figure[1, 3]; xlabel, ylabel, title="Initial salinity")
 
-heatmap!(axis_temperature, φ, z, initial_temperature)
-heatmap!(axis_salinity, φ, z, initial_salinity)
+hm_T = heatmap!(axis_temperature, φ, z, initial_temperature; colormap=:thermal)
+Colorbar(figure[1, 2], hm_T; label="ᵒC")
+hm_S = heatmap!(axis_salinity, φ, z, initial_salinity; colormap=:haline)
+Colorbar(figure[1, 4], hm_S; label="g / kg")
 
 save("initial_temperature_and_salinity.svg", figure)
 ```

--- a/src/GyreInABox.jl
+++ b/src/GyreInABox.jl
@@ -387,7 +387,7 @@ Maximal surface wind stress given parameters `p` in m² s⁻².
 $(SIGNATURES)
 """
 @inline function max_surface_wind_stress(p::GyreInABoxParameters)
-    -p.ρ_a / p.ρ_s * p.c_d * p.u_10^2
+    p.ρ_a / p.ρ_s * p.c_d * p.u_10^2
 end
 
 """
@@ -401,7 +401,7 @@ Computes wind stress in zonal direction at longitude `λ` and latitude `φ` (bot
 degrees), time `t` and with model parameters `p`.
 """
 function zonal_wind_stress(λ, φ, t, p::GyreInABoxParameters)
-    return -max_surface_wind_stress(p) * cos(2π * (φ - p.φ_u) / p.Lφ_u)
+    return max_surface_wind_stress(p) * cos(2π * (φ - p.φ_u) / p.Lφ_u)
 end
 
 """

--- a/src/GyreInABox.jl
+++ b/src/GyreInABox.jl
@@ -497,6 +497,17 @@ function setup_model(
 end
 
 """
+Sigmoidal depth profile which smoothly varies from `f_top` at `z = 0` to `f_bottom` at
+`z = -depth` with length scale for smooth transition `ℓ` and offset for midpoint of
+smooth transition `z_0`.
+
+$(SIGNATURES)
+"""
+function sigmoidal_depth_profile(z, z_0, ℓ, f_bottom, f_top)
+    f_bottom + (f_top - f_bottom) * (1  + tanh((z - z_0) / ℓ)) / 2
+end
+
+"""
 Initial temperature at latitude `φ` and depth `z` with parameters `p`.
 
 $(SIGNATURES)
@@ -508,9 +519,8 @@ profile which smoothly varies from a latitude dependent surface temperature to a
 constant deep ocean temperature with a sigmoidal profile.
 """
 function initial_temperature(φ, z, p)
-    p.T_abyssal + (
-        reference_surface_temperature(φ, p) - p.T_abyssal
-    ) * (1 + tanh((z - p.z_thermocline) / p.ℓ_thermocline)) / 2
+    T_surface = reference_surface_temperature(φ, p)
+    sigmoidal_depth_profile(z, p.z_thermocline, p.ℓ_thermocline, p.T_abyssal, T_surface)
 end
 
 """
@@ -525,9 +535,8 @@ which smoothly varies from a latitude dependent surface salinity to a constant
 deep ocean salinity with a sigmoidal profile.
 """
 function initial_salinity(φ, z, p)
-    p.S_0 + (
-        reference_surface_salinity(φ, p) - p.S_0
-    ) * (1 + tanh((z - p.z_halocline) / p.ℓ_halocline)) / 2
+    S_surface = reference_surface_salinity(φ, p)
+    sigmoidal_depth_profile(z, p.z_halocline, p.ℓ_halocline, p.S_0, S_surface)
 end
 
 """


### PR DESCRIPTION
Resolves #8 

Uses a relaxation boundary condition at surface for salinity that restores to a latitude dependent reference salinity roughly matching salinity latitude dependence in north Atlantic. Also updates salinity initial condition to use a halocline like profile smoothly varying from reference salinity at surface to a constant background salinity at bottom. Randomisation of initial velocity and temperature fields also removed as this was found to have limited effect on dynamics and parameter names rationalised.