### PR TITLE
Add functionality for plotting temporal averages of recorded field output

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -113,7 +113,7 @@ configuration = SimulationConfiguration(
     progress_message_interval=400
 )
 run_simulation(parameters, configuration)
-record_animations(parameters, configuration)
+plot_outputs(AnimationPlotOutput(), parameters, configuration)
 nothing # hide
 ```
 

--- a/src/GyreInABox.jl
+++ b/src/GyreInABox.jl
@@ -60,9 +60,9 @@ export setup_model, initialize!, setup_simulation
 export AnimationPlotOutput, TemporalAveragePlotOutput
 export run_simulation, plot_outputs
 
+include("outputs.jl")
 include("models.jl")
 include("simulations.jl")
-include("outputs.jl")
 include("utils.jl")
 include("double_gyre.jl")
 include("spall_2011.jl")

--- a/src/GyreInABox.jl
+++ b/src/GyreInABox.jl
@@ -57,7 +57,8 @@ export SimulationConfiguration
 export HorizontalSlice, LongitudeDepthSlice, LatitudeDepthSlice, XDepthSlice, YDepthSlice
 export DepthAveraged, FreeSurfaceFields, MOCStreamFunction, BarotropicStreamFunction
 export setup_model, initialize!, setup_simulation
-export run_simulation, record_animations
+export AnimationPlotOutput, TemporalAveragePlotOutput
+export run_simulation, plot_outputs
 
 include("models.jl")
 include("simulations.jl")

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -525,6 +525,113 @@ function add_output_writers!(
 end
 
 """
+Get properties for customizing plot axis rendering for `output_type` on `grid`.
+"""
+axis_properties(output_type, grid) = (
+    xlabel=axis_xlabel(output_type, grid),
+    ylabel=axis_ylabel(output_type, grid),
+    aspect=AxisAspect(axis_aspect_ratio(output_type, grid)),
+    limits=axis_limits(output_type, grid),
+)
+
+function ordered_field_variables(
+    field_timeseries, variable_plot_configurations, exclude_variables
+)
+    sort(
+        tuple(
+            setdiff(
+                keys(field_timeseries) ∩ keys(variable_plot_configurations),
+                exclude_variables,
+            )...,
+        );
+        # Sort by tuple of variable name length and variable so that decorated variable
+        # names appear after undecorated variables
+        by=variable -> (length(variable), variable),
+    )
+end
+
+function get_variable_plot_configurations(plot_configuration_overrides)
+    if isnothing(plot_configuration_overrides)
+        DEFAULT_VARIABLE_PLOT_CONFIGURATIONS
+    else
+        merge(DEFAULT_VARIABLE_PLOT_CONFIGURATIONS, plot_configuration_overrides)
+    end
+end
+
+function plot_grid_dimensions(n_fields, max_columns)
+    n_columns = min(n_fields, max_columns)
+    n_rows = cld(n_fields, n_columns)
+    return (n_columns, n_rows)
+end
+
+function plot_row_column_indices(variable_index, n_columns)
+    row = (variable_index - 1) ÷ n_columns + 2
+    col = ((variable_index - 1) % n_columns) * 2 + 1
+    return (row, col)
+end
+
+function setup_figure(n_rows, n_columns, axis_width, axis_height, title_height)
+    Figure(;
+        # CairoMakie defaults to px_per_unit=2 so manually adjust figure size here to
+        # account for this - this is done in preference to changing px_per_unit using
+        # CairoMakie.activate! to avoid persisting change after function exit
+        size=(axis_width * n_columns / 2, (axis_height * n_rows + title_height) / 2),
+        fontsize=12,
+    )
+end
+
+function create_fields_plot_output(
+    plot_field_on_axis!,
+    get_title,
+    save_output,
+    output_kwargs,
+    output_filename_stem::String,
+    output_type::AbstractOutput,
+    grid::AbstractGrid;
+    max_columns::Int=3,
+    axis_width::Int=640,
+    axis_height::Int=480,
+    title_height::Int=40,
+    exclude_variables::Tuple=(),
+    plot_configuration_overrides::Union{Dict,Nothing}=nothing
+)
+    filepath = output_filename(output_filename_stem, output_type)
+    field_timeseries = FieldDataset(filepath).fields
+
+    axis_kwargs = axis_properties(output_type, grid)
+
+    variable_plot_configurations = get_variable_plot_configurations(plot_configuration_overrides)
+
+    field_variables = ordered_field_variables(
+        field_timeseries, variable_plot_configurations, exclude_variables
+    )
+
+    n_columns, n_rows = plot_grid_dimensions(length(field_variables), max_columns)
+
+    fig = setup_figure(n_rows, n_columns, axis_width, axis_height, title_height)
+
+    times = first(values(field_timeseries)).times
+
+    time_index = Observable(1)
+
+    for (variable_index, variable) in enumerate(field_variables)
+        config = variable_plot_configurations[variable]
+        row, col = plot_row_column_indices(variable_index, n_columns)
+        axis = Axis(fig[row, col]; title=config.label, axis_kwargs...)
+        artist = plot_field_on_axis!(axis, field_timeseries[variable], time_index, config; output_kwargs...)
+        Colorbar(fig[row, col + 1], artist; label=config.unit)
+    end
+
+    title = get_title(time_index, times; output_kwargs...)
+
+    fig[1, 1:(n_columns * 2)] = Label(fig, title; fontsize=20, tellwidth=false)
+
+    save_output(fig, times, time_index, output_filename_stem, output_type; output_kwargs...)
+
+    fig
+end
+
+"""
 Record animation of fields recorded as model output.
 
 $(SIGNATURES)
@@ -548,88 +655,102 @@ by passing a dictionary `plot_configuration_overrides` with keys corresponding t
 variable names to override. Specific variables to exclude from plot can be specified
 in a tuple of variable names `exclude_variables`.
 """
-function record_animation(
+function record_animations(
     output_filename_stem::String,
     output_type::AbstractOutput,
     grid::AbstractGrid;
     frame_rate::Int=10,
-    max_columns::Int=3,
-    axis_width::Int=640,
-    axis_height::Int=480,
-    title_height::Int=40,
-    exclude_variables::Tuple=(),
-    plot_configuration_overrides::Union{Dict,Nothing}=nothing,
     frame_step::Int=1,
+    plot_kwargs...
 )
-    filepath = output_filename(output_filename_stem, output_type)
-    field_timeseries = FieldDataset(filepath).fields
 
-    axis_kwargs = (
-        xlabel=axis_xlabel(output_type, grid),
-        ylabel=axis_ylabel(output_type, grid),
-        aspect=AxisAspect(axis_aspect_ratio(output_type, grid)),
-        limits=axis_limits(output_type, grid),
-    )
+    function plot_field_on_axis!(axis, field_timeseries, time_index, config; kwargs...)
+        color_range = variable_limits(config.limits, field_timeseries)
+        field = @lift field_timeseries[$time_index]
+        heatmap!(axis, field; colormap=config.color_map, colorrange=color_range)
+    end
 
-    variable_plot_configurations = (
-        if isnothing(plot_configuration_overrides)
-            DEFAULT_VARIABLE_PLOT_CONFIGURATIONS
-        else
-            merge(DEFAULT_VARIABLE_PLOT_CONFIGURATIONS, plot_configuration_overrides)
+    function get_title(time_index, times; kwargs...)
+        @lift @sprintf("t = %s", prettytime(times[$time_index]))
+    end
+
+    function save_output(fig, times, time_index, output_filename_stem, output_type; frame_step, frame_rate)
+        frames = 1:frame_step:length(times)
+
+        output_file = output_filename(output_filename_stem, output_type, "mp4")
+        @info "Recording an animation of $(label(output_type)) to $(output_file)..."
+
+        CairoMakie.record(fig, output_file, frames; framerate=frame_rate) do i
+            (i % 10 == 0) && @printf "Plotting frame %i of %i\n" i frames[end]
+            time_index[] = i
         end
-    )
-
-    field_variables = sort(
-        tuple(
-            setdiff(
-                keys(field_timeseries) ∩ keys(variable_plot_configurations),
-                exclude_variables,
-            )...,
-        );
-        # Sort by tuple of variable name length and variable so that decorated variable
-        # names appear after undecorated variables
-        by=variable -> (length(variable), variable),
-    )
-
-    n_fields = length(field_variables)
-    n_columns = min(n_fields, max_columns)
-    n_rows = cld(n_fields, n_columns)
-
-    fig = Figure(;
-        # CairoMakie defaults to px_per_unit=2 so manually adjust figure size here to
-        # account for this - this is done in preference to changing px_per_unit using
-        # CairoMakie.activate! to avoid persisting change after function exit
-        size=(axis_width * n_columns / 2, (axis_height * n_rows + title_height) / 2),
-        fontsize=12,
-    )
-
-    times = first(values(field_timeseries)).times
-    time_index = Observable(1)
-
-    for (variable_index, variable) in enumerate(field_variables)
-        config = variable_plot_configurations[variable]
-        color_range = variable_limits(config.limits, field_timeseries[variable])
-        field = @lift field_timeseries[variable][$time_index]
-        row = (variable_index - 1) ÷ n_columns + 2
-        col = ((variable_index - 1) % n_columns) * 2 + 1
-        axis = Axis(fig[row, col]; title=config.label, axis_kwargs...)
-        hmap = heatmap!(axis, field; colormap=config.color_map, colorrange=color_range)
-        Colorbar(fig[row, col + 1], hmap; label=config.unit)
     end
 
-    title = @lift @sprintf("t = %s", prettytime(times[$time_index]))
+    create_fields_plot_output(
+        plot_field_on_axis!,
+        get_title,
+        save_output,
+        (; frame_rate, frame_step),
+        output_filename_stem,
+        output_type,
+        grid;
+        plot_kwargs...,
+    )
+end
 
-    fig[1, 1:(n_columns * 2)] = Label(fig, title; fontsize=20, tellwidth=false)
+"""
+Plot temporal averages of fields recorded as model output.
 
-    frames = 1:frame_step:length(times)
+$(SIGNATURES)
 
-    output_file = output_filename(output_filename_stem, output_type, "mp4")
-    @info "Recording an animation of $(label(output_type)) to $(output_file)..."
+## Details
 
-    CairoMakie.record(fig, output_file, frames; framerate=frame_rate) do i
-        (i % 10 == 0) && @printf "Plotting frame %i of %i\n" i frames[end]
-        time_index[] = i
+Computes temporal averages for filename stem `output_filename_stem` of model outputs for
+output type `output_type` and for a model grid `grid`. The simulation
+must have already been run for a model with this grid and with specified output type
+active.
+
+The temporal averages are plotted as filled contour plots with `levels` levels, with fields
+arranged on a grid with a maximum of `max_columns` columns, with the axis for each
+field contour plot of size `(axis_width, axis_height)` in pixels and a further `title_height`
+pixels allowed at the top of the figure.
+
+By default the plot configurations for each field variable are taken from the
+`GyreInABox.DEFAULT_VARIABLE_PLOT_CONFIGURATIONS` dictionary but these can be overridden
+by passing a dictionary `plot_configuration_overrides` with keys corresponding to the
+variable names to override. Specific variables to exclude from plot can be specified
+in a tuple of variable names `exclude_variables`.
+"""
+function plot_time_averages(
+    output_filename_stem::String,
+    output_type::AbstractOutput,
+    grid::AbstractGrid;
+    levels::Union{AbstractVector, Int} = 10,
+    plot_kwargs...
+)
+
+    function plot_field_on_axis!(axis, field_timeseries, time_index, config; levels)
+        # mean(field_timeseries, dims=4) errors on Oceananigans v105.2 so manually construct mean
+        mean_field = sum(field_timeseries, dims=4) / length(field_timeseries)
+        contourf!(axis, mean_field; colormap=config.color_map, levels=levels)
     end
 
-    fig
+    function get_title(time_index, times; kwargs...)
+        @sprintf("Time average from\n%s to %s", prettytime(times[1]), prettytime(times[end]))
+    end
+
+    function save_output(fig, times, time_index, output_filename_stem, output_type; kwargs...)
+        save(output_filename(output_filename_stem, output_type, "svg"), fig)
+    end
+
+    create_fields_plot_output(
+        plot_field_on_axis!,
+        get_title,
+        save_output,
+        (; levels),
+        output_filename_stem,
+        output_type,
+        grid;
+        plot_kwargs...,
+    )
 end

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -580,11 +580,146 @@ function setup_figure(n_rows, n_columns, axis_width, axis_height, title_height)
     )
 end
 
-function create_fields_plot_output(
-    plot_field_on_axis!,
-    get_title,
-    save_output,
-    output_kwargs,
+abstract type AbstractPlotOutput end
+
+"""
+    $(FUNCTIONNAME)(axis, plot_output_type, field_timeseries, time_index, config)
+
+Plots visual representation of `field_timeseries` appropriate for `plot_output_type`
+output type on `axis`, optionally using observable `time_index` to index into
+`field_timeseries` and with plot configuration options for variable represented
+in `field_timeseries` specified in `config`.
+
+$(TYPEDSIGNATURES)
+"""
+function plot_field_on_axis! end
+
+"""
+    $(FUNCTIONNAME)(plot_output_type, time_index, times)
+
+Constructs figure title for `plot_output_type` output type optionally using information
+about simulation times in `times` and observable time index `time_index`.
+
+$(TYPEDSIGNATURES)
+"""
+function get_title end
+
+"""
+    $(FUNCTIONNAME)(
+        plot_output_type,
+        fig,
+        times,
+        time_index,
+        output_filename_stem,
+        model_output_type
+    )
+
+Saves plot file output for `plot_output_type` and `model_output_type` visualized on
+Makie figure `fig` with model outputs recorded with `output_filename_step`, optionally
+using simulation times `times` and observable `time_index`.
+
+$(TYPEDSIGNATURES)
+"""
+function save_output end
+
+"""
+$(TYPEDEF)
+
+Animated field plot output type.
+
+## Details
+
+Specifies recording an animation of model output fields recording during a simulation.
+
+Animation is recorded with a frame rate of `frame_rate` frames per second and each
+frame of animation steps `frame_step` time indices through field time series.
+"""
+@kwdef struct AnimationPlotOutput <: AbstractPlotOutput
+    frame_rate::Int = 10
+    frame_step::Int = 1
+end
+
+function plot_field_on_axis!(axis, ::AnimationPlotOutput, field_timeseries, time_index, config)
+    color_range = variable_limits(config.limits, field_timeseries)
+    field = @lift field_timeseries[$time_index]
+    heatmap!(axis, field; colormap=config.color_map, colorrange=color_range)
+end
+
+function get_title(::AnimationPlotOutput, time_index, times)
+    @lift @sprintf("t = %s", prettytime(times[$time_index]))
+end
+
+function save_output(
+    plot_output_type::AnimationPlotOutput, fig, times, time_index, output_filename_stem, model_output_type
+)
+    frames = 1:plot_output_type.frame_step:length(times)
+
+    output_file = output_filename(output_filename_stem, model_output_type, "mp4")
+    @info "Recording an animation of $(label(model_output_type)) to $(output_file)..."
+
+    CairoMakie.record(fig, output_file, frames; framerate=plot_output_type.frame_rate) do i
+        (i % 10 == 0) && @printf "Plotting frame %i of %i\n" i frames[end]
+        time_index[] = i
+    end
+end
+
+"""
+$(TYPEDEF)
+
+Field temporal average plot output type.
+
+## Details
+
+Specifies plotting temporal average of model output fields recording during a simulation.
+
+The temporal averages are plotted as filled contour plots with `levels` levels, either
+an integer specifying number of levels with range automatically determined or a vector
+of specific edge values to use.
+"""
+@kwdef struct TemporalAveragePlotOutput{V <: AbstractVector} <: AbstractPlotOutput
+    levels::Union{Int, V} = 10
+end
+
+function plot_field_on_axis!(axis, plot_output::TemporalAveragePlotOutput, field_timeseries, time_index, config)
+    # mean(field_timeseries, dims=4) errors on Oceananigans v105.2 so manually construct mean
+    mean_field = sum(field_timeseries, dims=4) / length(field_timeseries)
+    contourf!(axis, mean_field; colormap=config.color_map, levels=plot_output.levels)
+end
+
+function get_title(::TemporalAveragePlotOutput, time_index, times)
+    @sprintf("Time average from\n%s to %s", prettytime(times[1]), prettytime(times[end]))
+end
+
+function save_output(::TemporalAveragePlotOutput, fig, times, time_index, output_filename_stem, model_output)
+    save(output_filename(output_filename_stem, model_output, "svg"), fig)
+end
+
+"""
+Create plot of fields recorded as model output.
+
+$(SIGNATURES)
+
+## Details
+
+Generates and record to file with filename stem `output_filename_stem` an animation of
+model outputs for output type `output_type` and for a model grid `grid`. The simulation
+must have already been run for a model with this grid and with specified output type
+active.
+
+Animation is recorded with a frame rate of `frame_rate` frames per second, with fields
+arranged on a grid with a maximum of `max_columns` columns, with the axis for each
+field heatmap of size `(axis_width, axis_height)` in pixels and a further `title_height`
+pixels allowed at the top of the figure for a title showing the simulation time. Each
+frame of animation steps `frame_step` time indices through field time series.
+
+By default the plot configurations for each field variable are taken from the
+`GyreInABox.DEFAULT_VARIABLE_PLOT_CONFIGURATIONS` dictionary but these can be overridden
+by passing a dictionary `plot_configuration_overrides` with keys corresponding to the
+variable names to override. Specific variables to exclude from plot can be specified
+in a tuple of variable names `exclude_variables`.
+"""
+function plot_output(
+    plot_output_type::AbstractPlotOutput,
     output_filename_stem::String,
     output_type::AbstractOutput,
     grid::AbstractGrid;
@@ -618,139 +753,17 @@ function create_fields_plot_output(
         config = variable_plot_configurations[variable]
         row, col = plot_row_column_indices(variable_index, n_columns)
         axis = Axis(fig[row, col]; title=config.label, axis_kwargs...)
-        artist = plot_field_on_axis!(axis, field_timeseries[variable], time_index, config; output_kwargs...)
+        artist = plot_field_on_axis!(
+            axis, plot_output_type,  field_timeseries[variable], time_index, config
+        )
         Colorbar(fig[row, col + 1], artist; label=config.unit)
     end
 
-    title = get_title(time_index, times; output_kwargs...)
+    title = get_title(plot_output_type, time_index, times)
 
     fig[1, 1:(n_columns * 2)] = Label(fig, title; fontsize=20, tellwidth=false)
 
-    save_output(fig, times, time_index, output_filename_stem, output_type; output_kwargs...)
+    save_output(plot_output_type, fig, times, time_index, output_filename_stem, output_type)
 
     fig
-end
-
-"""
-Record animation of fields recorded as model output.
-
-$(SIGNATURES)
-
-## Details
-
-Generates and record to file with filename stem `output_filename_stem` an animation of
-model outputs for output type `output_type` and for a model grid `grid`. The simulation
-must have already been run for a model with this grid and with specified output type
-active.
-
-Animation is recorded with a frame rate of `frame_rate` frames per second, with fields
-arranged on a grid with a maximum of `max_columns` columns, with the axis for each
-field heatmap of size `(axis_width, axis_height)` in pixels and a further `title_height`
-pixels allowed at the top of the figure for a title showing the simulation time. Each
-frame of animation steps `frame_step` time indices through field time series.
-
-By default the plot configurations for each field variable are taken from the
-`GyreInABox.DEFAULT_VARIABLE_PLOT_CONFIGURATIONS` dictionary but these can be overridden
-by passing a dictionary `plot_configuration_overrides` with keys corresponding to the
-variable names to override. Specific variables to exclude from plot can be specified
-in a tuple of variable names `exclude_variables`.
-"""
-function record_animations(
-    output_filename_stem::String,
-    output_type::AbstractOutput,
-    grid::AbstractGrid;
-    frame_rate::Int=10,
-    frame_step::Int=1,
-    plot_kwargs...
-)
-
-    function plot_field_on_axis!(axis, field_timeseries, time_index, config; kwargs...)
-        color_range = variable_limits(config.limits, field_timeseries)
-        field = @lift field_timeseries[$time_index]
-        heatmap!(axis, field; colormap=config.color_map, colorrange=color_range)
-    end
-
-    function get_title(time_index, times; kwargs...)
-        @lift @sprintf("t = %s", prettytime(times[$time_index]))
-    end
-
-    function save_output(fig, times, time_index, output_filename_stem, output_type; frame_step, frame_rate)
-        frames = 1:frame_step:length(times)
-
-        output_file = output_filename(output_filename_stem, output_type, "mp4")
-        @info "Recording an animation of $(label(output_type)) to $(output_file)..."
-
-        CairoMakie.record(fig, output_file, frames; framerate=frame_rate) do i
-            (i % 10 == 0) && @printf "Plotting frame %i of %i\n" i frames[end]
-            time_index[] = i
-        end
-    end
-
-    create_fields_plot_output(
-        plot_field_on_axis!,
-        get_title,
-        save_output,
-        (; frame_rate, frame_step),
-        output_filename_stem,
-        output_type,
-        grid;
-        plot_kwargs...,
-    )
-end
-
-"""
-Plot temporal averages of fields recorded as model output.
-
-$(SIGNATURES)
-
-## Details
-
-Computes temporal averages for filename stem `output_filename_stem` of model outputs for
-output type `output_type` and for a model grid `grid`. The simulation
-must have already been run for a model with this grid and with specified output type
-active.
-
-The temporal averages are plotted as filled contour plots with `levels` levels, with fields
-arranged on a grid with a maximum of `max_columns` columns, with the axis for each
-field contour plot of size `(axis_width, axis_height)` in pixels and a further `title_height`
-pixels allowed at the top of the figure.
-
-By default the plot configurations for each field variable are taken from the
-`GyreInABox.DEFAULT_VARIABLE_PLOT_CONFIGURATIONS` dictionary but these can be overridden
-by passing a dictionary `plot_configuration_overrides` with keys corresponding to the
-variable names to override. Specific variables to exclude from plot can be specified
-in a tuple of variable names `exclude_variables`.
-"""
-function plot_time_averages(
-    output_filename_stem::String,
-    output_type::AbstractOutput,
-    grid::AbstractGrid;
-    levels::Union{AbstractVector, Int} = 10,
-    plot_kwargs...
-)
-
-    function plot_field_on_axis!(axis, field_timeseries, time_index, config; levels)
-        # mean(field_timeseries, dims=4) errors on Oceananigans v105.2 so manually construct mean
-        mean_field = sum(field_timeseries, dims=4) / length(field_timeseries)
-        contourf!(axis, mean_field; colormap=config.color_map, levels=levels)
-    end
-
-    function get_title(time_index, times; kwargs...)
-        @sprintf("Time average from\n%s to %s", prettytime(times[1]), prettytime(times[end]))
-    end
-
-    function save_output(fig, times, time_index, output_filename_stem, output_type; kwargs...)
-        save(output_filename(output_filename_stem, output_type, "svg"), fig)
-    end
-
-    create_fields_plot_output(
-        plot_field_on_axis!,
-        get_title,
-        save_output,
-        (; levels),
-        output_filename_stem,
-        output_type,
-        grid;
-        plot_kwargs...,
-    )
 end

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -230,12 +230,15 @@ $(TYPEDSIGNATURES)
 function label(::AbstractModelOutput) end
 
 label(output::HorizontalSlice) = Symbol("horizontal_slice_at_depth_$(output.depth)m")
+
 function label(output::LongitudeDepthSlice)
     Symbol("longitude_depth_slice_at_latitude_$(output.latitude)deg")
 end
+
 function label(output::LatitudeDepthSlice)
     Symbol("latitude_depth_slice_at_longitude_$(output.longitude)deg")
 end
+
 label(output::XDepthSlice) = Symbol("x_depth_slice_at_y_$(output.y)m")
 label(output::YDepthSlice) = Symbol("y_depth_slice_at_x_$(output.x)m")
 label(::DepthAveraged) = :depth_averaged
@@ -253,15 +256,19 @@ indices(::AbstractModelOutput, grid) = (:, :, :)
 function indices(output::HorizontalSlice, grid)
     (:, :, clamp(searchsortedfirst(znodes(grid, Face()), output.depth), 1:grid.Nz))
 end
+
 function indices(output::LongitudeDepthSlice, grid)
     (:, clamp(searchsortedfirst(φnodes(grid, Face()), output.latitude), 1:grid.Ny), :)
 end
+
 function indices(output::LatitudeDepthSlice, grid)
     (clamp(searchsortedfirst(λnodes(grid, Face()), output.longitude), 1:grid.Nx), :, :)
 end
+
 function indices(output::XDepthSlice, grid)
     (:, clamp(searchsortedfirst(ynodes(grid, Face()), output.y), 1:grid.Ny), :)
 end
+
 function indices(output::YDepthSlice, grid)
     (clamp(searchsortedfirst(xnodes(grid, Face()), output.x), 1:grid.Nx), :, :)
 end
@@ -274,12 +281,14 @@ $(TYPEDSIGNATURES)
 function outputs(::AbstractModelOutput, model) end
 
 outputs(::SliceOutputs, model) = merge(model.velocities, model.tracers)
+
 function outputs(::DepthAveraged, model)
     NamedTuple(
         name => Field(Average(variable; dims=3)) for
         (name, variable) in pairs(merge(model.velocities, model.tracers))
     )
 end
+
 function outputs(
     ::FreeSurfaceFields,
     model::HydrostaticFreeSurfaceModel{
@@ -288,12 +297,14 @@ function outputs(
 ) where {TS,E,A}
     (; η=model.free_surface.displacement)
 end
+
 function outputs(
     ::FreeSurfaceFields,
     model::HydrostaticFreeSurfaceModel{TS,E,A,<:SplitExplicitFreeSurface},
 ) where {TS,E,A}
     merge((; η=model.free_surface.displacement), model.free_surface.barotropic_velocities)
 end
+
 function outputs(::MOCStreamFunction, model)
     (;
         # Scale velocities by 1 / 10⁶ so doubly spatially integrated field is in
@@ -305,6 +316,7 @@ function outputs(::MOCStreamFunction, model)
         )
     )
 end
+
 function outputs(::BarotropicStreamFunction, model)
     (;
         # Scale velocities by 1 / 10⁶ so doubly spatially integrated field is in
@@ -335,7 +347,10 @@ For an output `output` a label computed using `label` function is appended on to
 function output_filename(stem::String, label::Symbol, extension::String)
     "$(stem)_$(label).$(extension)"
 end
-function output_filename(stem::String, output::AbstractModelOutput, extension::String="jld2")
+
+function output_filename(
+    stem::String, output::AbstractModelOutput, extension::String="jld2"
+)
     output_filename(stem, label(output), extension)
 end
 
@@ -408,21 +423,27 @@ function axis_limits end
 function axis_limits(::AbstractHorizontalModelOutput, grid::LatitudeLongitudeGrid)
     (extrema(λnodes(grid, Face())), extrema(φnodes(grid, Face())))
 end
+
 function axis_limits(::LongitudeDepthSlice, grid::LatitudeLongitudeGrid)
     (extrema(λnodes(grid, Face())), extrema(znodes(grid, Face())))
 end
+
 function axis_limits(::LatitudeDepthOutputs, grid::LatitudeLongitudeGrid)
     (extrema(φnodes(grid, Face())), extrema(znodes(grid, Face())))
 end
+
 function axis_limits(::AbstractHorizontalModelOutput, grid::RectilinearGrid)
     (extrema(xnodes(grid, Face())), extrema(ynodes(grid, Face())))
 end
+
 function axis_limits(::XDepthSlice, grid::RectilinearGrid)
     (extrema(xnodes(grid, Face())), extrema(znodes(grid, Face())))
 end
+
 function axis_limits(::YDepthOutputs, grid::RectilinearGrid)
     (extrema(ynodes(grid, Face())), extrema(znodes(grid, Face())))
 end
+
 function axis_limits(output::AbstractModelOutput, grid::ImmersedBoundaryGrid)
     (axis_limits(output, grid.underlying_grid))
 end
@@ -530,12 +551,14 @@ Get properties for customizing plot axis rendering for `model_output` on `grid`.
 
 $(SIGNATURES)
 """
-axis_properties(model_output, grid) = (
-    xlabel=axis_xlabel(model_output, grid),
-    ylabel=axis_ylabel(model_output, grid),
-    aspect=AxisAspect(axis_aspect_ratio(model_output, grid)),
-    limits=axis_limits(model_output, grid),
-)
+function axis_properties(model_output, grid)
+    (
+        xlabel=axis_xlabel(model_output, grid),
+        ylabel=axis_ylabel(model_output, grid),
+        aspect=AxisAspect(axis_aspect_ratio(model_output, grid)),
+        limits=axis_limits(model_output, grid),
+    )
+end
 
 """
 Get ordered sequence of field variables to plot from `field_time_series`
@@ -675,7 +698,9 @@ $(TYPEDFIELDS)
     frame_step::Int = 1
 end
 
-function plot_field_on_axis!(axis, ::AnimationPlotOutput, field_timeseries, time_index, config)
+function plot_field_on_axis!(
+    axis, ::AnimationPlotOutput, field_timeseries, time_index, config
+)
     color_range = variable_limits(config.limits, field_timeseries)
     field = @lift field_timeseries[$time_index]
     heatmap!(axis, field; colormap=config.color_map, colorrange=color_range)
@@ -686,7 +711,12 @@ function get_title(::AnimationPlotOutput, time_index, times)
 end
 
 function save_output(
-    plot_output::AnimationPlotOutput, fig, times, time_index, output_filename_stem, model_output
+    plot_output::AnimationPlotOutput,
+    fig,
+    times,
+    time_index,
+    output_filename_stem,
+    model_output,
 )
     frames = 1:plot_output.frame_step:length(times)
 
@@ -712,7 +742,7 @@ The temporal averages are plotted as filled contour plots.
 
 $(TYPEDFIELDS)
 """
-@kwdef struct TemporalAveragePlotOutput{L <: Union{Int, AbstractVector}} <: AbstractPlotOutput
+@kwdef struct TemporalAveragePlotOutput{L<:Union{Int,AbstractVector}} <: AbstractPlotOutput
     """
     Either an integer specifying number of contour levels with range automatically
     determined or a vector of specific edge values to use.
@@ -720,9 +750,11 @@ $(TYPEDFIELDS)
     levels::L = 10
 end
 
-function plot_field_on_axis!(axis, plot_output::TemporalAveragePlotOutput, field_timeseries, time_index, config)
+function plot_field_on_axis!(
+    axis, plot_output::TemporalAveragePlotOutput, field_timeseries, time_index, config
+)
     # mean(field_timeseries, dims=4) errors on Oceananigans v105.2 so manually construct mean
-    mean_field = sum(field_timeseries, dims=4) / length(field_timeseries)
+    mean_field = sum(field_timeseries; dims=4) / length(field_timeseries)
     contourf!(axis, mean_field; colormap=config.color_map, levels=plot_output.levels)
 end
 
@@ -730,7 +762,9 @@ function get_title(::TemporalAveragePlotOutput, time_index, times)
     @sprintf("Time average from\n%s to %s", prettytime(times[1]), prettytime(times[end]))
 end
 
-function save_output(::TemporalAveragePlotOutput, fig, times, time_index, output_filename_stem, model_output)
+function save_output(
+    ::TemporalAveragePlotOutput, fig, times, time_index, output_filename_stem, model_output
+)
     save(output_filename(output_filename_stem, model_output, "svg"), fig)
 end
 
@@ -768,14 +802,16 @@ function plot_output(
     axis_height::Int=480,
     title_height::Int=40,
     exclude_variables::Tuple=(),
-    plot_configuration_overrides::Union{Dict,Nothing}=nothing
+    plot_configuration_overrides::Union{Dict,Nothing}=nothing,
 )
     filepath = output_filename(output_filename_stem, model_output)
     field_timeseries = FieldDataset(filepath).fields
 
     axis_kwargs = axis_properties(model_output, grid)
 
-    variable_plot_configurations = get_variable_plot_configurations(plot_configuration_overrides)
+    variable_plot_configurations = get_variable_plot_configurations(
+        plot_configuration_overrides
+    )
 
     field_variables = ordered_field_variables(
         field_timeseries, variable_plot_configurations, exclude_variables
@@ -794,7 +830,7 @@ function plot_output(
         row, col = plot_row_column_indices(variable_index, n_columns)
         axis = Axis(fig[row, col]; title=config.label, axis_kwargs...)
         artist = plot_field_on_axis!(
-            axis, plot_output_type,  field_timeseries[variable], time_index, config
+            axis, plot_output_type, field_timeseries[variable], time_index, config
         )
         Colorbar(fig[row, col + 1], artist; label=config.unit)
     end
@@ -803,7 +839,9 @@ function plot_output(
 
     fig[1, 1:(n_columns * 2)] = Label(fig, title; fontsize=20, tellwidth=false)
 
-    save_output(plot_output_type, fig, times, time_index, output_filename_stem, model_output)
+    save_output(
+        plot_output_type, fig, times, time_index, output_filename_stem, model_output
+    )
 
     fig
 end

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -677,12 +677,12 @@ The temporal averages are plotted as filled contour plots.
 
 $(TYPEDFIELDS)
 """
-@kwdef struct TemporalAveragePlotOutput{V <: AbstractVector} <: AbstractPlotOutput
+@kwdef struct TemporalAveragePlotOutput{L <: Union{Int, AbstractVector}} <: AbstractPlotOutput
     """
     Either an integer specifying number of contour levels with range automatically
     determined or a vector of specific edge values to use.
     """
-    levels::Union{Int, V} = 10
+    levels::L = 10
 end
 
 function plot_field_on_axis!(axis, plot_output::TemporalAveragePlotOutput, field_timeseries, time_index, config)

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -1,8 +1,8 @@
-abstract type AbstractOutput{S} end
+abstract type AbstractModelOutput{S} end
 
-abstract type AbstractHorizontalOutput{S} <: AbstractOutput{S} end
+abstract type AbstractHorizontalModelOutput{S} <: AbstractModelOutput{S} end
 
-abstract type AbstractVerticalOutput{S} <: AbstractOutput{S} end
+abstract type AbstractVerticalModelOutput{S} <: AbstractModelOutput{S} end
 
 """
 $(TYPEDEF)
@@ -17,7 +17,7 @@ Records horizontal slices through model velocity and tracer fields at specified 
 
 $(TYPEDFIELDS)
 """
-@kwdef struct HorizontalSlice{S,T} <: AbstractHorizontalOutput{S}
+@kwdef struct HorizontalSlice{S,T} <: AbstractHorizontalModelOutput{S}
     "Depth of slice / m"
     depth::T = 0.0
     "Schedule to record output at"
@@ -37,7 +37,7 @@ Records vertical slices through model velocity and tracer fields at specified la
 
 $(TYPEDFIELDS)
 """
-@kwdef struct LongitudeDepthSlice{S,T} <: AbstractVerticalOutput{S}
+@kwdef struct LongitudeDepthSlice{S,T} <: AbstractVerticalModelOutput{S}
     "Latitude of slice / °"
     latitude::T = 45.0
     "Schedule to record output at"
@@ -57,7 +57,7 @@ Records vertical slices through model velocity and tracer fields at specified lo
 
 $(TYPEDFIELDS)
 """
-@kwdef struct LatitudeDepthSlice{S,T} <: AbstractVerticalOutput{S}
+@kwdef struct LatitudeDepthSlice{S,T} <: AbstractVerticalModelOutput{S}
     "Longitude of slice / °"
     longitude::T = 30.0
     "Schedule to record output at"
@@ -77,7 +77,7 @@ Records vertical slices through model velocity and tracer fields at specified y 
 
 $(TYPEDFIELDS)
 """
-@kwdef struct XDepthSlice{S,T} <: AbstractVerticalOutput{S}
+@kwdef struct XDepthSlice{S,T} <: AbstractVerticalModelOutput{S}
     "y coordinate of slice / m"
     y::T = 1000.0
     "Schedule to record output at"
@@ -97,7 +97,7 @@ Records vertical slices through model velocity and tracer fields at specified x 
 
 $(TYPEDFIELDS)
 """
-@kwdef struct YDepthSlice{S,T} <: AbstractVerticalOutput{S}
+@kwdef struct YDepthSlice{S,T} <: AbstractVerticalModelOutput{S}
     "x coordinate of slice / m"
     x::T = 500.0
     "Schedule to record output at"
@@ -121,7 +121,7 @@ Records two-dimensional free surface (height and barotropic velocity) fields.
 
 $(TYPEDFIELDS)
 """
-@kwdef struct FreeSurfaceFields{S} <: AbstractHorizontalOutput{S}
+@kwdef struct FreeSurfaceFields{S} <: AbstractHorizontalModelOutput{S}
     "Time interval to record output at / s"
     schedule::S = TimeInterval(1day)
 end
@@ -140,7 +140,7 @@ fields.
 
 $(TYPEDFIELDS)
 """
-@kwdef struct DepthAveraged{S} <: AbstractHorizontalOutput{S}
+@kwdef struct DepthAveraged{S} <: AbstractHorizontalModelOutput{S}
     "Schedule to record output at"
     schedule::S = AveragedTimeInterval(30day, window=30day)
 end
@@ -178,7 +178,7 @@ The outputted field is scaled to be in sverdrup (10⁶ m³ s⁻¹) units.
 
 $(TYPEDFIELDS)
 """
-@kwdef struct MOCStreamFunction{S} <: AbstractVerticalOutput{S}
+@kwdef struct MOCStreamFunction{S} <: AbstractVerticalModelOutput{S}
     schedule::S = AveragedTimeInterval(30day, window=30day)
 end
 
@@ -215,7 +215,7 @@ The outputted field is scaled to be in sverdrup (10⁶ m³ s⁻¹) units.
 
 $(TYPEDFIELDS)
 """
-@kwdef struct BarotropicStreamFunction{S} <: AbstractHorizontalOutput{S}
+@kwdef struct BarotropicStreamFunction{S} <: AbstractHorizontalModelOutput{S}
     schedule::S = AveragedTimeInterval(30day, window=30day)
 end
 
@@ -227,7 +227,7 @@ Symbol label for output type to use in naming output file and registering output
 
 $(TYPEDSIGNATURES)
 """
-function label(::AbstractOutput) end
+function label(::AbstractModelOutput) end
 
 label(output::HorizontalSlice) = Symbol("horizontal_slice_at_depth_$(output.depth)m")
 function label(output::LongitudeDepthSlice)
@@ -248,7 +248,7 @@ Spatial grid indices output type records fields at.
 
 $(TYPEDSIGNATURES)
 """
-indices(::AbstractOutput, grid) = (:, :, :)
+indices(::AbstractModelOutput, grid) = (:, :, :)
 
 function indices(output::HorizontalSlice, grid)
     (:, :, clamp(searchsortedfirst(znodes(grid, Face()), output.depth), 1:grid.Nz))
@@ -271,7 +271,7 @@ Named tuple of output variables (fields) to record for output type.
     
 $(TYPEDSIGNATURES)
 """
-function outputs(::AbstractOutput, model) end
+function outputs(::AbstractModelOutput, model) end
 
 outputs(::SliceOutputs, model) = merge(model.velocities, model.tracers)
 function outputs(::DepthAveraged, model)
@@ -320,7 +320,7 @@ Time schedule to record output type at.
 
 $(TYPEDSIGNATURES)
 """
-schedule(output::AbstractOutput) = output.schedule
+schedule(output::AbstractModelOutput) = output.schedule
 
 """
 Filename to record outputs to.
@@ -329,55 +329,55 @@ $(TYPEDSIGNATURES)
 
 ## Details
 
-For an output type `output` a label computed using `label` function is appended on to
+For an output `output` a label computed using `label` function is appended on to
 `stem`` and file extension is specified by `extension` added.
 """
 function output_filename(stem::String, label::Symbol, extension::String)
     "$(stem)_$(label).$(extension)"
 end
-function output_filename(stem::String, output::AbstractOutput, extension::String="jld2")
+function output_filename(stem::String, output::AbstractModelOutput, extension::String="jld2")
     output_filename(stem, label(output), extension)
 end
 
 """
-    $(FUNCTIONNAME)(output_type, grid)
+    $(FUNCTIONNAME)(output, grid)
 
-Label for horizontal axis for field heatmaps on grid `grid` for output type `output_type`.
+Label for horizontal axis for field heatmaps on grid `grid` for output `output`.
     
 $(TYPEDSIGNATURES)
 """
 function axis_xlabel end
 
-axis_xlabel(::AbstractHorizontalOutput, ::LatitudeLongitudeGrid) = "Longitude λ / ᵒ"
+axis_xlabel(::AbstractHorizontalModelOutput, ::LatitudeLongitudeGrid) = "Longitude λ / ᵒ"
 axis_xlabel(::LongitudeDepthSlice, ::LatitudeLongitudeGrid) = "Longitude λ / ᵒ"
 function axis_xlabel(::LatitudeDepthOutputs, ::LatitudeLongitudeGrid)
     "Latitude ϕ / ᵒ"
 end
-axis_xlabel(::AbstractHorizontalOutput, ::RectilinearGrid) = "x / m"
+axis_xlabel(::AbstractHorizontalModelOutput, ::RectilinearGrid) = "x / m"
 axis_xlabel(::XDepthSlice, ::RectilinearGrid) = "x / m"
 axis_xlabel(::YDepthOutputs, ::RectilinearGrid) = "y / m"
-function axis_xlabel(output_type::AbstractOutput, grid::ImmersedBoundaryGrid)
-    (axis_xlabel(output_type, grid.underlying_grid))
+function axis_xlabel(output::AbstractModelOutput, grid::ImmersedBoundaryGrid)
+    (axis_xlabel(output, grid.underlying_grid))
 end
 
 """
-    $(FUNCTIONNAME)(output_type, grid)
+    $(FUNCTIONNAME)(output, grid)
 
-Label for vertical axis for field heatmaps on grid `grid` for output type `output_type`.
+Label for vertical axis for field heatmaps on grid `grid` for output `output`.
     
 $(TYPEDSIGNATURES)
 """
 function axis_ylabel end
 
-axis_ylabel(::AbstractHorizontalOutput, ::LatitudeLongitudeGrid) = "Latitude ϕ / ᵒ"
-axis_ylabel(::AbstractHorizontalOutput, ::RectilinearGrid) = "y / m"
+axis_ylabel(::AbstractHorizontalModelOutput, ::LatitudeLongitudeGrid) = "Latitude ϕ / ᵒ"
+axis_ylabel(::AbstractHorizontalModelOutput, ::RectilinearGrid) = "y / m"
 function axis_ylabel(
-    ::AbstractVerticalOutput, ::Union{LatitudeLongitudeGrid,RectilinearGrid}
+    ::AbstractVerticalModelOutput, ::Union{LatitudeLongitudeGrid,RectilinearGrid}
 )
     "Depth z / m"
 end
-function axis_ylabel(output_type::AbstractOutput, grid::ImmersedBoundaryGrid)
-    axis_ylabel(output_type, grid.underlying_grid)
+function axis_ylabel(output::AbstractModelOutput, grid::ImmersedBoundaryGrid)
+    axis_ylabel(output, grid.underlying_grid)
 end
 
 """
@@ -385,27 +385,27 @@ Aspect ratio for field heatmaps.
     
 $(TYPEDSIGNATURES)
 """
-axis_aspect_ratio(::AbstractOutput, ::AbstractGrid) = 1
-function axis_aspect_ratio(::AbstractHorizontalOutput, grid::LatitudeLongitudeGrid)
+axis_aspect_ratio(::AbstractModelOutput, ::AbstractGrid) = 1
+function axis_aspect_ratio(::AbstractHorizontalModelOutput, grid::LatitudeLongitudeGrid)
     abs(-(extrema(λnodes(grid, Face()))...)) / abs(-(extrema(φnodes(grid, Face()))...))
 end
-function axis_aspect_ratio(::AbstractHorizontalOutput, grid::RectilinearGrid)
+function axis_aspect_ratio(::AbstractHorizontalModelOutput, grid::RectilinearGrid)
     abs(-(extrema(xnodes(grid, Face()))...)) / abs(-(extrema(ynodes(grid, Face()))...))
 end
-function axis_aspect_ratio(output_type::AbstractOutput, grid::ImmersedBoundaryGrid)
-    (axis_aspect_ratio(output_type, grid.underlying_grid))
+function axis_aspect_ratio(output::AbstractModelOutput, grid::ImmersedBoundaryGrid)
+    (axis_aspect_ratio(output, grid.underlying_grid))
 end
 
 """
-    $(FUNCTIONNAME)(output_type, grid)
+    $(FUNCTIONNAME)(output, grid)
 
-Axis limits for field heatmaps on grid `grid` for output type `output_type`.
+Axis limits for field heatmaps on grid `grid` for output type `output`.
     
 $(TYPEDSIGNATURES)
 """
 function axis_limits end
 
-function axis_limits(::AbstractHorizontalOutput, grid::LatitudeLongitudeGrid)
+function axis_limits(::AbstractHorizontalModelOutput, grid::LatitudeLongitudeGrid)
     (extrema(λnodes(grid, Face())), extrema(φnodes(grid, Face())))
 end
 function axis_limits(::LongitudeDepthSlice, grid::LatitudeLongitudeGrid)
@@ -414,7 +414,7 @@ end
 function axis_limits(::LatitudeDepthOutputs, grid::LatitudeLongitudeGrid)
     (extrema(φnodes(grid, Face())), extrema(znodes(grid, Face())))
 end
-function axis_limits(::AbstractHorizontalOutput, grid::RectilinearGrid)
+function axis_limits(::AbstractHorizontalModelOutput, grid::RectilinearGrid)
     (extrema(xnodes(grid, Face())), extrema(ynodes(grid, Face())))
 end
 function axis_limits(::XDepthSlice, grid::RectilinearGrid)
@@ -423,8 +423,8 @@ end
 function axis_limits(::YDepthOutputs, grid::RectilinearGrid)
     (extrema(ynodes(grid, Face())), extrema(znodes(grid, Face())))
 end
-function axis_limits(output_type::AbstractOutput, grid::ImmersedBoundaryGrid)
-    (axis_limits(output_type, grid.underlying_grid))
+function axis_limits(output::AbstractModelOutput, grid::ImmersedBoundaryGrid)
+    (axis_limits(output, grid.underlying_grid))
 end
 
 @kwdef struct AutoVariableLimits{T}
@@ -495,7 +495,8 @@ unit(variable_name::String) = DEFAULT_VARIABLE_PLOT_CONFIGURATIONS[variable_name
 unit(variable::Symbol) = unit(string(variable))
 
 """
-Register output writers for output types specified in `configuration` in `simulation`.
+Register output writers for output types in `output_types` in `simulation` using
+output filenames with stem `output_filename_stem`
 
 $(SIGNATURES)
 """
@@ -509,13 +510,13 @@ function add_output_writers!(
         isa(model.grid.architecture, CPU) ? model.grid : on_architecture(CPU(), model.grid)
     )
 
-    for output_type in output_types
-        simulation.output_writers[label(output_type)] = JLD2Writer(
+    for output in output_types
+        simulation.output_writers[label(output)] = JLD2Writer(
             model,
-            outputs(output_type, model);
-            filename=output_filename(output_filename_stem, output_type),
-            indices=indices(output_type, grid),
-            schedule=schedule(output_type),
+            outputs(output, model);
+            filename=output_filename(output_filename_stem, output),
+            indices=indices(output, grid),
+            schedule=schedule(output),
             overwrite_existing=true,
             with_halos=true,
         )
@@ -525,15 +526,24 @@ function add_output_writers!(
 end
 
 """
-Get properties for customizing plot axis rendering for `output_type` on `grid`.
+Get properties for customizing plot axis rendering for `model_output` on `grid`.
+
+$(SIGNATURES)
 """
-axis_properties(output_type, grid) = (
-    xlabel=axis_xlabel(output_type, grid),
-    ylabel=axis_ylabel(output_type, grid),
-    aspect=AxisAspect(axis_aspect_ratio(output_type, grid)),
-    limits=axis_limits(output_type, grid),
+axis_properties(model_output, grid) = (
+    xlabel=axis_xlabel(model_output, grid),
+    ylabel=axis_ylabel(model_output, grid),
+    aspect=AxisAspect(axis_aspect_ratio(model_output, grid)),
+    limits=axis_limits(model_output, grid),
 )
 
+"""
+Get ordered sequence of field variables to plot from `field_time_series`
+based on those for which plot configurations are defined in
+`variable_plot_configurations` and not excluded in `exclude_variables`.
+
+$(SIGNATURES)
+"""
 function ordered_field_variables(
     field_timeseries, variable_plot_configurations, exclude_variables
 )
@@ -550,6 +560,12 @@ function ordered_field_variables(
     )
 end
 
+"""
+Get dicitionary of per-variable plot configurations by merging user-provided
+overrides in `plot_configuration_overrides` with default configurations.
+
+$(SIGNATURES)
+"""
 function get_variable_plot_configurations(plot_configuration_overrides)
     if isnothing(plot_configuration_overrides)
         DEFAULT_VARIABLE_PLOT_CONFIGURATIONS
@@ -558,18 +574,37 @@ function get_variable_plot_configurations(plot_configuration_overrides)
     end
 end
 
+"""
+Compute dimensions of plot grid for `n_fields` fields with maximum number of
+grid columns `max_columns`.
+
+$(SIGNATURES)
+"""
 function plot_grid_dimensions(n_fields, max_columns)
     n_columns = min(n_fields, max_columns)
     n_rows = cld(n_fields, n_columns)
     return (n_columns, n_rows)
 end
 
+"""
+Compute figure row and column indices for axis for field variable indexed by
+`variable_index` for plot grid with `n_columns` columns.
+
+$(SIGNATURES)
+"""
 function plot_row_column_indices(variable_index, n_columns)
     row = (variable_index - 1) ÷ n_columns + 2
     col = ((variable_index - 1) % n_columns) * 2 + 1
     return (row, col)
 end
 
+"""
+Setup figure object of appropriate size for `n_rows` rows and `n_columns` of
+axis objects each of size `(axis_width, axis_height)` plus a top margin of
+`title_height` for inclusion of a figure title.
+
+$(SIGNATURES)
+"""
 function setup_figure(n_rows, n_columns, axis_width, axis_height, title_height)
     Figure(;
         # CairoMakie defaults to px_per_unit=2 so manually adjust figure size here to
@@ -583,9 +618,9 @@ end
 abstract type AbstractPlotOutput end
 
 """
-    $(FUNCTIONNAME)(axis, plot_output_type, field_timeseries, time_index, config)
+    $(FUNCTIONNAME)(axis, plot_output, field_timeseries, time_index, config)
 
-Plots visual representation of `field_timeseries` appropriate for `plot_output_type`
+Plots visual representation of `field_timeseries` appropriate for `plot_output`
 output type on `axis`, optionally using observable `time_index` to index into
 `field_timeseries` and with plot configuration options for variable represented
 in `field_timeseries` specified in `config`.
@@ -595,9 +630,9 @@ $(TYPEDSIGNATURES)
 function plot_field_on_axis! end
 
 """
-    $(FUNCTIONNAME)(plot_output_type, time_index, times)
+    $(FUNCTIONNAME)(plot_output, time_index, times)
 
-Constructs figure title for `plot_output_type` output type optionally using information
+Constructs figure title for `plot_output` output type optionally using information
 about simulation times in `times` and observable time index `time_index`.
 
 $(TYPEDSIGNATURES)
@@ -606,15 +641,15 @@ function get_title end
 
 """
     $(FUNCTIONNAME)(
-        plot_output_type,
+        plot_output,
         fig,
         times,
         time_index,
         output_filename_stem,
-        model_output_type
+        model_output
     )
 
-Saves plot file output for `plot_output_type` and `model_output_type` visualized on
+Saves plot file output for `plot_output` and `model_output` visualized on
 Makie figure `fig` with model outputs recorded with `output_filename_step`, optionally
 using simulation times `times` and observable `time_index`.
 
@@ -651,14 +686,14 @@ function get_title(::AnimationPlotOutput, time_index, times)
 end
 
 function save_output(
-    plot_output_type::AnimationPlotOutput, fig, times, time_index, output_filename_stem, model_output_type
+    plot_output::AnimationPlotOutput, fig, times, time_index, output_filename_stem, model_output
 )
-    frames = 1:plot_output_type.frame_step:length(times)
+    frames = 1:plot_output.frame_step:length(times)
 
-    output_file = output_filename(output_filename_stem, model_output_type, "mp4")
-    @info "Recording an animation of $(label(model_output_type)) to $(output_file)..."
+    output_file = output_filename(output_filename_stem, model_output, "mp4")
+    @info "Recording an animation of $(label(model_output)) to $(output_file)..."
 
-    CairoMakie.record(fig, output_file, frames; framerate=plot_output_type.frame_rate) do i
+    CairoMakie.record(fig, output_file, frames; framerate=plot_output.frame_rate) do i
         (i % 10 == 0) && @printf "Plotting frame %i of %i\n" i frames[end]
         time_index[] = i
     end
@@ -707,7 +742,7 @@ $(SIGNATURES)
 ## Details
 
 Generates and record to file with filename stem `output_filename_stem` an animation of
-model outputs for output type `output_type` and for a model grid `grid`. The simulation
+model outputs for output type `model_output` and for a model grid `grid`. The simulation
 must have already been run for a model with this grid and with specified output type
 active.
 
@@ -726,7 +761,7 @@ in a tuple of variable names `exclude_variables`.
 function plot_output(
     plot_output_type::AbstractPlotOutput,
     output_filename_stem::String,
-    output_type::AbstractOutput,
+    model_output::AbstractModelOutput,
     grid::AbstractGrid;
     max_columns::Int=3,
     axis_width::Int=640,
@@ -735,10 +770,10 @@ function plot_output(
     exclude_variables::Tuple=(),
     plot_configuration_overrides::Union{Dict,Nothing}=nothing
 )
-    filepath = output_filename(output_filename_stem, output_type)
+    filepath = output_filename(output_filename_stem, model_output)
     field_timeseries = FieldDataset(filepath).fields
 
-    axis_kwargs = axis_properties(output_type, grid)
+    axis_kwargs = axis_properties(model_output, grid)
 
     variable_plot_configurations = get_variable_plot_configurations(plot_configuration_overrides)
 
@@ -768,7 +803,7 @@ function plot_output(
 
     fig[1, 1:(n_columns * 2)] = Label(fig, title; fontsize=20, tellwidth=false)
 
-    save_output(plot_output_type, fig, times, time_index, output_filename_stem, output_type)
+    save_output(plot_output_type, fig, times, time_index, output_filename_stem, model_output)
 
     fig
 end

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -631,11 +631,12 @@ Animated field plot output type.
 
 Specifies recording an animation of model output fields recording during a simulation.
 
-Animation is recorded with a frame rate of `frame_rate` frames per second and each
-frame of animation steps `frame_step` time indices through field time series.
+$(TYPEDFIELDS)
 """
 @kwdef struct AnimationPlotOutput <: AbstractPlotOutput
+    "Frame rate (frames per second) to record animation at."
     frame_rate::Int = 10
+    "Number of time indices to step through in field time series on each frame."
     frame_step::Int = 1
 end
 
@@ -672,11 +673,15 @@ Field temporal average plot output type.
 
 Specifies plotting temporal average of model output fields recording during a simulation.
 
-The temporal averages are plotted as filled contour plots with `levels` levels, either
-an integer specifying number of levels with range automatically determined or a vector
-of specific edge values to use.
+The temporal averages are plotted as filled contour plots.
+
+$(TYPEDFIELDS)
 """
 @kwdef struct TemporalAveragePlotOutput{V <: AbstractVector} <: AbstractPlotOutput
+    """
+    Either an integer specifying number of contour levels with range automatically
+    determined or a vector of specific edge values to use.
+    """
     levels::Union{Int, V} = 10
 end
 

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -129,7 +129,7 @@ function plot_outputs(
     kwargs...
 )
     for output_type in configuration.output_types
-        plot_output(configuration.output_filename, output_type, grid; kwargs...)
+        plot_output(plot_output_type, configuration.output_filename, output_type, grid; kwargs...)
     end
 end
 
@@ -139,6 +139,6 @@ function plot_outputs(
     configuration::SimulationConfiguration;
     kwargs...
 )
-    plot_output(plot_output_type, grid(parameters, CPU()), configuration; kwargs...)
+    plot_outputs(plot_output_type, grid(parameters, CPU()), configuration; kwargs...)
 end
 

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -111,28 +111,34 @@ function run_simulation(
 end
 
 """
-Record animations of fields recorded as simulation output.
+Plot outputs of fields recorded as simulation output.
 
 $(SIGNATURES)
 
 ## Details
 
-Generates and record to files animations of model outputs on grid `grid` and 
-for a simulation configuration `configuration`. Keyword arguments `kwargs` 
-are passed through to [`record_animation()`](@ref) and can be used to customize
-plot output.
+Generates and record to files plots of type `plot_output_type` for model 
+outputs on grid `grid` and  for a simulation configuration `configuration`. 
+Keyword arguments `kwargs`  are passed through to [`plot_output()`](@ref)
+and can be used to customize plot output.
 """
-function record_animations(
-    grid::AbstractGrid, configuration::SimulationConfiguration; kwargs...
+function plot_outputs(
+    plot_output_type::AbstractPlotOutput,
+    grid::AbstractGrid,
+    configuration::SimulationConfiguration;
+    kwargs...
 )
     for output_type in configuration.output_types
-        record_animation(configuration.output_filename, output_type, grid; kwargs...)
+        plot_output(configuration.output_filename, output_type, grid; kwargs...)
     end
 end
 
-function record_animations(
-    parameters::AbstractParameters, configuration::SimulationConfiguration; kwargs...
+function plot_outputs(
+    plot_output_type::AbstractPlotOutput,
+    parameters::AbstractParameters,
+    configuration::SimulationConfiguration;
+    kwargs...
 )
-    record_animations(grid(parameters, CPU()), configuration; kwargs...)
+    plot_output(plot_output_type, grid(parameters, CPU()), configuration; kwargs...)
 end
 


### PR DESCRIPTION
Adds an additional plot output type to existing animations of fields across time, to instead allow plotting temporal averages.