### PR TITLE
Update turbulence closure configuration for Spall 2011 model

### DIFF
--- a/src/spall_2011.jl
+++ b/src/spall_2011.jl
@@ -76,12 +76,8 @@ $(TYPEDFIELDS)
     top_slope_width::T = 20kilometers
     "Whether to use CATKE rather than scalar vertical diffusivity turbulence closure"
     use_catke_closure::Bool = true
-    "Whether to include a Gent-McWilliams isopycnal diffusivity as a parameterization for the mesoscale eddy fluxes."
+    "Whether to include a dynamic Smagorinsky closure as a parameterization for eddy viscosity and diffusivity"
     use_eddy_closure::Bool = false
-    "Gent-McWilliams isopycnal diffusivity closure coefficient controlling eddy-induced transport"
-    eddy_induced_tranport_coefficient::T = 1e3
-    "Gent-McWilliams isopycnal diffusivity closure coefficient controlling along isopycnal diffusion"
-    isopycnal_diffusion_coefficient::T = 1e3
     "Whether to initialise with reference surface temperature or constant"
     initialize_with_reference_surface_temperature::Bool = true
     "Surface wind forcing ramp-up time scale / s"
@@ -268,11 +264,7 @@ function closure(parameters::Spall2011Parameters)
         )
     end
     if parameters.use_eddy_closure
-        eddy_closure = Oceananigans.TurbulenceClosures.IsopycnalSkewSymmetricDiffusivity(
-            κ_skew=parameters.eddy_induced_tranport_coefficient,
-            κ_symmetric=parameters.isopycnal_diffusion_coefficient,
-            skew_flux_formulation=Oceananigans.TurbulenceClosures.AdvectiveFormulation()
-        )
+        eddy_closure = DynamicSmagorinsky()
         (eddy_closure, vertical_mixing)
     else
         vertical_mixing

--- a/src/spall_2011.jl
+++ b/src/spall_2011.jl
@@ -79,7 +79,7 @@ $(TYPEDFIELDS)
     "Whether to use CATKE rather than scalar vertical diffusivity turbulence closure"
     use_catke_closure::Bool = false
     "Whether to include a dynamic Smagorinsky closure as a parameterization for eddy viscosity and diffusivity"
-    use_eddy_closure::Bool = false
+    use_eddy_closure::Bool = true
     "Whether to initialise with reference surface temperature or constant"
     initialize_with_reference_surface_temperature::Bool = true
     "Surface wind forcing ramp-up time scale / s"

--- a/src/spall_2011.jl
+++ b/src/spall_2011.jl
@@ -76,6 +76,12 @@ $(TYPEDFIELDS)
     top_slope_width::T = 20kilometers
     "Whether to use CATKE rather than scalar vertical diffusivity turbulence closure"
     use_catke_closure::Bool = true
+    "Whether to include a Gent-McWilliams isopycnal diffusivity as a parameterization for the mesoscale eddy fluxes."
+    use_eddy_closure::Bool = false
+    "Gent-McWilliams isopycnal diffusivity closure coefficient controlling eddy-induced transport"
+    eddy_induced_tranport_coefficient::T = 1e3
+    "Gent-McWilliams isopycnal diffusivity closure coefficient controlling along isopycnal diffusion"
+    isopycnal_diffusion_coefficient::T = 1e3
     "Whether to initialise with reference surface temperature or constant"
     initialize_with_reference_surface_temperature::Bool = true
     "Surface wind forcing ramp-up time scale / s"
@@ -253,13 +259,23 @@ function buoyancy(parameters::Spall2011Parameters)
 end
 
 function closure(parameters::Spall2011Parameters)
-    if parameters.use_catke_closure
+    vertical_mixing = if parameters.use_catke_closure
         CATKEVerticalDiffusivity()
     else
         VerticalScalarDiffusivity(;
             ν=parameters.vertical_viscosity_coefficient,
             κ=parameters.vertical_diffusivity_coefficient,
         )
+    end
+    if parameters.use_eddy_closure
+        eddy_closure = Oceananigans.TurbulenceClosures.IsopycnalSkewSymmetricDiffusivity(
+            κ_skew=parameters.eddy_induced_tranport_coefficient,
+            κ_symmetric=parameters.isopycnal_diffusion_coefficient,
+            skew_flux_formulation=Oceananigans.TurbulenceClosures.AdvectiveFormulation()
+        )
+        (eddy_closure, vertical_mixing)
+    else
+        vertical_mixing
     end
 end
 

--- a/src/spall_2011.jl
+++ b/src/spall_2011.jl
@@ -77,7 +77,7 @@ $(TYPEDFIELDS)
     "Width of slope on top wall of domain / m"
     top_slope_width::T = 20kilometers
     "Whether to use CATKE rather than scalar vertical diffusivity turbulence closure"
-    use_catke_closure::Bool = true
+    use_catke_closure::Bool = false
     "Whether to include a dynamic Smagorinsky closure as a parameterization for eddy viscosity and diffusivity"
     use_eddy_closure::Bool = false
     "Whether to initialise with reference surface temperature or constant"

--- a/src/spall_2011.jl
+++ b/src/spall_2011.jl
@@ -38,6 +38,8 @@ $(TYPEDFIELDS)
     vertical_viscosity_coefficient::T = 1e-5
     "Vertical scalar diffusivity turbulence closure coefficient / m² s⁻¹"
     vertical_diffusivity_coefficient::T = 1e-5
+    "Enhanced vertical scalar diffusivity coefficient in statically unstable conditions / m² s⁻¹"
+    convective_vertical_diffusivity_coefficient::T = 1000.
     "Thermal expansion coefficient / kg m⁻³ K⁻¹"
     thermal_expansion_coefficient::T = 0.2
     "Sea water reference density / kg m⁻³"
@@ -258,9 +260,11 @@ function closure(parameters::Spall2011Parameters)
     vertical_mixing = if parameters.use_catke_closure
         CATKEVerticalDiffusivity()
     else
-        VerticalScalarDiffusivity(;
-            ν=parameters.vertical_viscosity_coefficient,
-            κ=parameters.vertical_diffusivity_coefficient,
+        ConvectiveAdjustmentVerticalDiffusivity(;
+            background_νz=parameters.vertical_viscosity_coefficient,
+            background_κz=parameters.vertical_diffusivity_coefficient,
+            convective_νz=parameters.vertical_viscosity_coefficient,
+            convective_κz=parameters.convective_vertical_diffusivity_coefficient,
         )
     end
     if parameters.use_eddy_closure


### PR DESCRIPTION
Switches default vertical mixing closure to `ConvectiveAdjustmentVerticalDiffusivity` to reflect set up described in paper 

> The model incorporates second-order vertical viscosity and diffusivity with coefficients $10^{-5}\\,\text{m}^2\text{s}^{-1}$. The vertical diffusion is increased to $1000\\,\text{m}^2\text{s}^{-1}$ for statically unstable conditions in order to represent vertical convection. 

with viscosity and diffusivity parameters defaulting to those specified in paper.

Also adds a `DynamicSmagorinsky` eddy closure, enabled by default. This differs from the (constant / static coefficient) Smagorinsky closure prescribed in the paper

> Horizontal viscosity is parameterized as a second-order operator with the coefficient $A_h$, determined by a [Smagorinsky (1963)](https://journals.ametsoc.org/view/journals/clim/24/18/2011jcli4130.1.xml#bib18) closure as $A_h = (\nu_s / \pi)^2 \Delta^2[(u_x-v_y)^2 + (u_y + v_x)^2)]^{\frac{1}{2}}$, where $\nu_s = 2.5$ is a nondimensional coefficient, Δ is the grid spacing, and u and υ are the horizontal velocities (subscripts indicate partial differentiation)

however, using the `Smagorinsky` closure in Oceananigans (which I believe is the closest equivalent to what is described above) seems to give unstable numerical integration even for small values of coefficient.