### PR TITLE
Scale salinity flux in Spall 2011 / 2012 model by current salinity

### DIFF
--- a/src/spall_2011.jl
+++ b/src/spall_2011.jl
@@ -173,8 +173,13 @@ end
         p.domain_size_y
     end
     p.southern_surface_temperature +
-    min((max(y - p.southern_region_extent, 0) / (northern_temperature_y - p.southern_region_extent)), 1) *
-    (p.northern_surface_temperature - p.southern_surface_temperature)
+    min(
+        (
+            max(y - p.southern_region_extent, 0) /
+            (northern_temperature_y - p.southern_region_extent)
+        ),
+        1,
+    ) * (p.northern_surface_temperature - p.southern_surface_temperature)
 end
 
 @inline function surface_temperature_flux(

--- a/src/spall_2011.jl
+++ b/src/spall_2011.jl
@@ -347,3 +347,47 @@ function initialize!(model::Oceananigans.AbstractModel, parameters::Spall2011Par
     set!(model; u=0.0, v=0.0, S=parameters.reference_salinity, T=T_initial)
     nothing
 end
+
+function plot_domain_and_forcing(
+    parameters::Spall2011Parameters; axis_height::Int=600, axis_width::Int=400
+)
+    grid = GyreInABox.grid(parameters, CPU())
+    temperature_field = CenterField(grid; indices=(:, :, grid.Nz))
+    set!(temperature_field, (x, y, z) -> reference_surface_temperature(x, y, parameters))
+    figure = Figure(; size=(axis_width * 4, axis_height), fontsize=12)
+    aspect = AxisAspect(parameters.domain_size_x / parameters.domain_size_y)
+    xlabel = "x / m"
+    ylabel = "y / m"
+    limits = ((0.0, parameters.domain_size_x), (0.0, parameters.domain_size_y))
+    ax1 = Axis(figure[1, 1]; title="Bottom depth / m", aspect, xlabel, ylabel, limits)
+    ax2 = Axis(
+        figure[1, 3];
+        title="Reference surface temperature / °C",
+        aspect,
+        xlabel,
+        ylabel,
+        limits,
+    )
+    ax3 = Axis(figure[1, 5]; title="Surface zonal velocity flux / m² s⁻²", aspect, ylabel)
+    ax4 = Axis(
+        figure[1, 6];
+        title="Surface net evaporation - precipitation / m s⁻¹",
+        aspect,
+        ylabel,
+    )
+    c1 = contourf!(ax1, -grid.immersed_boundary.bottom_height; colormap=:deep)
+    Colorbar(figure[1, 2], c1)
+    c2 = contourf!(ax2, temperature_field; colormap=:thermal, levels=2:11)
+    Colorbar(figure[1, 4], c2)
+    y = ynodes(grid, Face())
+    lines!(
+        ax3,
+        zonal_surface_wind_stress.(
+            nothing, y, parameters.surface_wind_forcing_ramp_up_timescale, (parameters,)
+        ),
+        y,
+    )
+    lines!(ax4, surface_evaporation_minus_precipitation.(y, (parameters,)), y)
+    resize_to_layout!(figure)
+    figure
+end

--- a/src/spall_2011.jl
+++ b/src/spall_2011.jl
@@ -51,10 +51,10 @@ $(TYPEDFIELDS)
     sea_water_density::T = 1026.0
     "Sea water specific heat capacity / J K⁻¹ kg⁻¹"
     sea_water_heat_capacity::T = 3991.0
-    "Reference salinity level used for initialisation and southern region forcing / psu"
+    "Reference salinity level used for initialisation and southern region forcing"
     reference_salinity::T = 35.0
-    "Surface salinity flux in northern basin above sill / m s⁻¹"
-    northern_basin_surface_salinity_flux::T = 2e-8
+    "Surface net evaporation-precipitation (salinity flux coefficient) in northern basin above sill / m s⁻¹"
+    northern_basin_surface_evaporation::T = -2e-8
     "Northern boundary surface temperature / °C"
     northern_surface_temperature::T = 2.0
     "Distance north along western boundary that surface temperature reaches limit / m"
@@ -188,9 +188,16 @@ end
     )
 end
 
-@inline surface_salinity_flux(x, y, t, p::Spall2011Parameters) = (
-    y > p.sill_center_y ? p.northern_basin_surface_salinity_flux : 0.0
+@inline surface_evaporation_minus_precipitation(y, p::Spall2011Parameters) = (
+    y > p.sill_center_y ? p.northern_basin_surface_evaporation : 0.0
 )
+
+@inline function surface_salinity_flux(
+    i, j, grid, clock, model_fields, p::Spall2011Parameters
+)
+    y = ynode(i, j, 1, grid, Center(), Center(), Center())
+    @inbounds -model_fields.S[i, j, grid.Nz] * surface_evaporation_minus_precipitation(y, p)
+end
 
 @inline function southern_region_mask(x, y, z, p::Spall2011Parameters)
     if p.southern_boundary_window_width == 0
@@ -249,7 +256,7 @@ function boundary_conditions(parameters::Spall2011Parameters{T}) where {T}
         top=FluxBoundaryCondition(meridional_surface_wind_stress; parameters)
     )
     S_bcs = FieldBoundaryConditions(;
-        top=FluxBoundaryCondition(surface_salinity_flux; parameters)
+        top=FluxBoundaryCondition(surface_salinity_flux; discrete_form=true, parameters)
     )
     T_bcs = FieldBoundaryConditions(;
         top=FluxBoundaryCondition(surface_temperature_flux; discrete_form=true, parameters)


### PR DESCRIPTION
Changes the surface salinity flux boundary condition in Spall 2011 / 2012 model configuration to have a flux of the form $-E S$ where $E$ is a net evaporation-precipitation rate (in m/s) and $S$ is the salinity field, rather than a constant flux of $-E$. From the dimensionality of equation 2 in Spall (2012) this appears to be consistent with what is assumed there. An alternative would be to use a fixed reference salinity value $S_0$ in flux such that the flux is $-E S_0$ but this should not differ significantly from scheme here assuming $S$ remains close to $S_0$.