### PR TITLE
Change tracer advections scheme to WENO

### DIFF
--- a/src/double_gyre.jl
+++ b/src/double_gyre.jl
@@ -277,6 +277,8 @@ forcing(::DoubleGyreParameters) = NamedTuple()
 
 momentum_advection(::DoubleGyreParameters) = Oceananigans.WENOVectorInvariant()
 
+tracer_advection(::DoubleGyreParameters) = Oceananigans.WENO()
+
 coriolis(::DoubleGyreParameters) = HydrostaticSphericalCoriolis()
 
 closure(::DoubleGyreParameters) = CATKEVerticalDiffusivity()

--- a/src/models.jl
+++ b/src/models.jl
@@ -68,6 +68,13 @@ Construct momentum advection scheme for ocean gyre model with parameters `parame
 function momentum_advection end
 
 """
+    $(FUNCTIONNAME)(parameters)
+
+Construct tracer advection scheme for ocean gyre model with parameters `parameters`.
+"""
+function tracer_advection end
+
+"""
 Set up ocean gyre model with parameters `parameters` on grid with architecture `architecture`.
 
 $(SIGNATURES)
@@ -76,6 +83,7 @@ function setup_model(parameters::AbstractParameters; architecture=CPU())
     HydrostaticFreeSurfaceModel(
         grid(parameters, architecture);
         momentum_advection=momentum_advection(parameters),
+        tracer_advection=tracer_advection(parameters),
         coriolis=coriolis(parameters),
         closure=closure(parameters),
         buoyancy=buoyancy(parameters),

--- a/src/spall_2011.jl
+++ b/src/spall_2011.jl
@@ -95,6 +95,8 @@ $(TYPEDFIELDS)
     initialize_with_reference_surface_temperature::Bool = true
     "Surface wind forcing ramp-up time scale / s"
     surface_wind_forcing_ramp_up_timescale::T = 10day
+    "Order of WENO advection schemes for momentum and tracers"
+    advection_order::Int = 5
 end
 
 function zonal_surface_wind_stress(x, y, t, parameters::Spall2011Parameters)
@@ -333,7 +335,8 @@ function coriolis(parameters::Spall2011Parameters)
     BetaPlane(parameters.coriolis_offset, parameters.coriolis_coefficient)
 end
 tracers(parameters::Spall2011Parameters) = (:T, :S)
-momentum_advection(parameters::Spall2011Parameters) = Oceananigans.WENOVectorInvariant()
+momentum_advection(parameters::Spall2011Parameters) = Oceananigans.WENOVectorInvariant(order=parameters.advection_order)
+tracer_advection(parameters::Spall2011Parameters) = Oceananigans.WENO(order=parameters.advection_order)
 
 function initialize!(model::Oceananigans.AbstractModel, parameters::Spall2011Parameters)
     function T_initial(x, y, z)


### PR DESCRIPTION
Creates a new `tracer_advection` function which can have methods defined for model parameter types to set tracer advection scheme, with two current model configurations both updated to use WENO scheme by default (with default order 5) for tracer advection. Spall (2011) configuration also updated to allow changing WENO scheme order for both momentum and tracers from default value of 5.