### PR TITLE
Add scripts for running and post-processing Spall (2012) configuration + use workspaces

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         version:
           - '1.12'
-          - '1.10'
           - 'pre'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 
 [compat]
-Aqua = "0.8.14"
 CairoMakie = "0.15.7"
 DocStringExtensions = "0.9.5"
 JLD2 = "0.6.4"
@@ -21,12 +20,7 @@ Oceananigans = "0.105, 0.106"
 Printf = "1.10.0"
 Random = "1.10.0"
 SeawaterPolynomials = "0.3.10"
-Test = "1.10.0"
-julia = "1.10.0"
+julia = "1.12.0"
 
-[extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Aqua", "Test"]
+[workspace]
+projects = ["test", "docs"]

--- a/Project.toml
+++ b/Project.toml
@@ -23,4 +23,4 @@ SeawaterPolynomials = "0.3.10"
 julia = "1.12.0"
 
 [workspace]
-projects = ["test", "docs"]
+projects = ["test", "docs", "scripts"]

--- a/scripts/Project.toml
+++ b/scripts/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+GyreInABox = "d40f67ff-4a83-48da-8213-065d3ac3739e"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
+
+[sources]
+GyreInABox = {path = ".."}
+
+[compat]
+ArgParse ="1.2.0"
+CUDA = "5.11.0"

--- a/scripts/spall_2012.jl
+++ b/scripts/spall_2012.jl
@@ -1,0 +1,108 @@
+using ArgParse
+using GyreInABox
+using JLD2
+using Oceananigans
+using Oceananigans.Units
+using CUDA
+using Dates: now, format
+
+function parse_commandline()
+    s = ArgParseSettings()
+
+    @add_arg_table s begin
+        "--surface-temperature-restoring-strength", "-R"
+            help = "Surface temperature restoring strength / W m⁻² K⁻¹"
+            arg_type = Float64
+            default = 20.
+        "--northern-basin-surface-evaporation", "-E"
+            help = "Surface net evaporation-precipitation in northern basin above sill / m s⁻¹"
+            arg_type = Float64
+            default = -2e-8
+        "--sill-height", "-H"
+            help = "Sill height / m"
+            arg_type = Float64
+            default = 1000.
+        "--simulation-years", "-Y"
+            help = "Number of simulated year to run for"
+            arg_type = Float64
+            default = 100.
+        "--output-interval-days", "-I"
+            help = "Interval at which to record outputs at in simulated days"
+            arg_type = Float64
+            default = 30.
+        "--grid-size", "-G"
+            help = "Grid dimensions in x, y and depth"
+            nargs = 3
+            arg_type = Int
+            default = [200, 400, 30]
+        "--cpu"
+            help = "Run on CPU (rather than GPU, the default)"
+            action = :store_true
+        "--use-eddy-closure"
+            help = "Use a dynamic Smagorinsky eddy closure"
+            action = :store_true
+    end
+
+    return parse_args(s)
+end
+
+function main()
+
+    args = parse_commandline()
+
+    @info "Parsed args:"
+    for (arg, val) in args
+        @info "  $arg: $val"
+    end
+
+    architecture = args["cpu"] ? CPU() : GPU()
+
+    output_interval = args["output-interval-days"] * 1day
+
+    parameters = Spall2011Parameters(;
+        grid_size=Tuple(args["grid-size"]),
+        surface_temperature_restoring_strength=args["surface-temperature-restoring-strength"],
+        northern_basin_surface_evaporation=args["northern-basin-surface-evaporation"],
+        sill_height=args["sill-height"],
+        use_eddy_closure=args["use-eddy-closure"],
+    )
+
+    mask = GyreInABox.northern_basin_mask(parameters)
+
+    configuration = SimulationConfiguration(
+        architecture=architecture,
+        simulation_time=args["simulation-years"]*365day,
+        initial_timestep=10minute,
+        maximum_timestep=60minute,
+        wizard_max_change=1.1,
+        wizard_update_interval=10,
+        output_filename="spall_2012_gyre_model",
+        output_types=(
+            HorizontalSlice(schedule=TimeInterval(output_interval)),
+            HorizontalSlice(depth=parameters.bottom_depth + parameters.sill_height, schedule=TimeInterval(output_interval)),
+            XDepthSlice(y_or_latitude=parameters.sill_center_y, schedule=TimeInterval(output_interval)),
+            YDepthSlice(x_or_longitude=parameters.domain_size_x / 2, schedule=TimeInterval(output_interval)),
+            FreeSurfaceFields(schedule=TimeInterval(output_interval)),
+            MOCStreamFunction(),
+            BarotropicStreamFunction(),
+            MOCStrength(y_or_latitude=parameters.sill_center_y),
+            MeridionalHeatTransport(y_or_latitude=parameters.sill_center_y),
+            AverageKineticEnergy(region_mask=mask),
+            HorizontallyAveragedTracers(region_mask=mask),
+        ),
+        progress_message_interval=1000
+    )
+    
+    timestamp = format(now(), "yyyy-mm-dd_HH-MM-SS")
+
+    run_directory = mkdir("$timestamp-run")
+    cd(run_directory)
+
+    jldsave("parameters.jld2"; parameters)
+    jldsave("configuration.jld2"; configuration)
+
+    run_simulation(parameters, configuration)
+
+end
+
+main()

--- a/scripts/spall_2012_post_process.jl
+++ b/scripts/spall_2012_post_process.jl
@@ -1,0 +1,165 @@
+using ArgParse
+using GyreInABox
+using JLD2
+using Oceananigans
+using Oceananigans.Units
+using CairoMakie
+
+function parse_commandline()
+    s = ArgParseSettings()
+
+    @add_arg_table s begin
+        "run-output-path"
+        help = "Path to directory containing run outputs"
+        arg_type = String
+        required = true
+        "--plot-time-range", "-t"
+        help = "Time range for plots in format (start, step, end) in days"
+        arg_type = Float64
+        nargs = 3
+        "--output-filename-suffix", "-o"
+        help = "Output filename suffix for summary plot"
+        arg_type = String
+        default = "summary"
+    end
+
+    return parse_args(s)
+end
+
+function main()
+    args = parse_commandline()
+
+    parameters = load("$(args["run-output-path"])/parameters.jld2")["parameters"]
+    configuration = load("$(args["run-output-path"])/configuration.jld2")["configuration"]
+
+    outputs = Dict()
+
+    for output_type in (
+        HorizontallyAveragedTracers,
+        AverageKineticEnergy,
+        MOCStrength,
+        MeridionalHeatTransport,
+    )
+        output_type_index = findfirst(ot -> ot isa output_type, configuration.output_types)
+        outputs[output_type] = if !isnothing(output_type_index)
+            configuration.output_types[output_type_index]
+        else
+            nothing
+        end
+    end
+
+    plot_times = if !isempty(args["plot-time-range"])
+        start, step, stop = args["plot-time-range"] .* 1day
+        range(start, stop; step)
+    else
+        nothing
+    end
+
+    fig = Figure(; size=(1200, 800))
+
+    row = 2
+
+    if !isnothing(outputs[HorizontallyAveragedTracers])
+        averaged_tracers_output = outputs[HorizontallyAveragedTracers]
+        S_timeseries = FieldTimeSeries(
+            "$(args["run-output-path"])/$(GyreInABox.output_filename(configuration.output_filename, averaged_tracers_output))",
+            "S";
+            backend=InMemory(),
+            times=plot_times,
+        )
+        T_timeseries = FieldTimeSeries(
+            "$(args["run-output-path"])/$(GyreInABox.output_filename(configuration.output_filename, averaged_tracers_output))",
+            "T";
+            backend=InMemory(),
+            times=plot_times,
+        )
+        ρ_timeseries = (
+            parameters.sea_water_density .+ stack(
+                (parameters.haline_contraction_coefficient * S_timeseries[t] - parameters.thermal_expansion_coefficient * T_timeseries[t])[
+                    1, 1, 1:parameters.grid_size[3]
+                ] for t in 1:length(S_timeseries)
+            )
+        )
+        times = S_timeseries.times / 365days
+        depths = znodes(S_timeseries)
+
+        col = 1
+        for (label, timeseries, cmap) in [
+            (
+                "Salinity / g kg⁻¹",
+                S_timeseries[1, 1, 1:parameters.grid_size[3], 1:length(times)],
+                :haline,
+            ),
+            (
+                "Temperature / °C",
+                T_timeseries[1, 1, 1:parameters.grid_size[3], 1:length(times)],
+                :thermal,
+            ),
+            ("Density / kg m⁻³", ρ_timeseries, :dense),
+        ]
+            ax = Axis(
+                fig[row, col];
+                title=label,
+                xlabel="Time / years",
+                ylabel="Depth / m",
+                limits=(extrema(times), extrema(depths)),
+            );
+            col += 1
+            cf = contourf!(ax, times, depths, timeseries'; colormap=cmap)
+            Colorbar(fig[row, col], cf)
+            col += 1
+        end
+
+        row += 1
+    end
+
+    col = 1
+
+    for (output_type, field_name, label) in (
+        (AverageKineticEnergy, "eₖ", "Average kinetic energy / m²s⁻²"),
+        (MOCStrength, "W", "MOC strength / Sv"),
+        (MeridionalHeatTransport, "Q", "Meridional heat transport / TW"),
+    )
+        if !isnothing(outputs[output_type])
+            output = outputs[output_type]
+            timeseries = FieldTimeSeries(
+                "$(args["run-output-path"])/$(GyreInABox.output_filename(configuration.output_filename, output))",
+                field_name;
+                backend=InMemory(),
+                times=plot_times,
+            )
+            times = timeseries.times / 365days
+            ax = Axis(
+                fig[row, col:(col + 1)];
+                title=label,
+                xlabel="Time / years",
+                limits=(extrema(times), nothing),
+            )
+            dims = size(timeseries)
+            indices = timeseries.indices
+            indices = Tuple(
+                s == 1 && indices[i] != Colon() ? first(indices[i]) : (s > 1 ? Colon() : 1)
+                for (i, s) in enumerate(dims)
+            )
+            lines!(ax, times, timeseries[indices...])
+            col += 2
+        end
+    end
+
+    fig[1, 1:end] = Label(
+        fig,
+        "Γ = $(parameters.surface_temperature_restoring_strength) Wm⁻²K⁻¹ and " *
+        "E = $(parameters.northern_basin_surface_evaporation / 1e-8)×10⁻⁸ ms⁻¹";
+        fontsize=20,
+        tellwidth=false,
+    )
+
+    resize_to_layout!(fig)
+
+    output_path = "$(args["run-output-path"])/$(configuration.output_filename)_$(args["output-filename-suffix"]).svg"
+
+    @info "Writing output figure to $(output_path)"
+    save(output_path, fig)
+end
+
+main()

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,11 +1,13 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GyreInABox = "d40f67ff-4a83-48da-8213-065d3ac3739e"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 GyreInABox = {path = ".."}
 
 [compat]
-Documenter = "1.17.0"
+Aqua = "0.8.14"
+Test = "1.10.0"


### PR DESCRIPTION
Adds two command line scripts for running Spall (2012) model configuration and post-processing simulation outputs and also switches to using a workspace project layout with separate `Project.toml` files in all of `test`, `docs` and `scripts` directories. As this is a Julia v1.12+ feature compatibility also upped accordingly.