### PR TITLE
Add MPI support to Spall (2012) run script

### DIFF
--- a/scripts/Project.toml
+++ b/scripts/Project.toml
@@ -4,11 +4,12 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 GyreInABox = "d40f67ff-4a83-48da-8213-065d3ac3739e"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 
 [sources]
 GyreInABox = {path = ".."}
 
 [compat]
-ArgParse ="1.2.0"
+ArgParse = "1.2.0"
 CUDA = "5.11.0"

--- a/scripts/spall_2012.jl
+++ b/scripts/spall_2012.jl
@@ -50,6 +50,10 @@ function parse_commandline()
         "--mpi"
             help = "Use MPI to distribute computations"
             action = :store_true
+        "--ranks-along-x"
+            help = "Number of ranks to distribute x dimension of grid along if using MPI"
+            arg_type = Int
+            default = 1
         "--use-eddy-closure"
             help = "Use a dynamic Smagorinsky eddy closure"
             action = :store_true
@@ -69,7 +73,9 @@ function main()
     architecture = args["cpu"] ? CPU() : GPU()
 
     if args["mpi"]
-        architecture = Distributed(architecture)
+        partition = Partition(x=args["ranks-along-x"], y=Equal())
+        @onrank 0 @info partition
+        architecture = Distributed(architecture; partition)
     end
 
     output_interval = args["output-interval-days"] * 1day

--- a/scripts/spall_2012.jl
+++ b/scripts/spall_2012.jl
@@ -64,12 +64,7 @@ function main()
 
     args["mpi"] && MPI.Init()
 
-    @onrank 0 begin
-        @info "Parsed args:"
-        for (arg, val) in args
-            @info "  $arg: $val"
-        end
-    end
+    @onrank 0 @info "Parsed args\n  " * join(("$arg = $val" for (arg, val) in args), "\n  ")
 
     architecture = args["cpu"] ? CPU() : GPU()
 
@@ -93,7 +88,11 @@ function main()
     timestamp = format(now(), "yyyy-mm-dd_HH-MM-SS")
 
     run_directory = joinpath(args["output-directory"], "$timestamp-run")
-    @onrank 0 mkdir(run_directory)
+
+    @onrank 0 begin
+        mkdir(run_directory)
+        @info "Writing outputs to $run_directory"
+    end
 
     configuration = SimulationConfiguration(
         architecture=architecture,

--- a/scripts/spall_2012.jl
+++ b/scripts/spall_2012.jl
@@ -2,8 +2,10 @@ using ArgParse
 using GyreInABox
 using JLD2
 using Oceananigans
+using Oceananigans.DistributedComputations
 using Oceananigans.Units
 using CUDA
+using MPI
 using Dates: now, format
 
 function parse_commandline()
@@ -35,8 +37,18 @@ function parse_commandline()
             nargs = 3
             arg_type = Int
             default = [200, 400, 30]
+        "--free-surface-substeps", "-S"
+            help = "Number of substeps to use in split-explicit free surface scheme (defaults to adaptive if not specified)"
+            arg_type = Int
+        "--output-directory", "-O"
+            help = "Directory to write outputs to"
+            arg_type = String
+            default = "."
         "--cpu"
             help = "Run on CPU (rather than GPU, the default)"
+            action = :store_true
+        "--mpi"
+            help = "Use MPI to distribute computations"
             action = :store_true
         "--use-eddy-closure"
             help = "Use a dynamic Smagorinsky eddy closure"
@@ -50,12 +62,20 @@ function main()
 
     args = parse_commandline()
 
-    @info "Parsed args:"
-    for (arg, val) in args
-        @info "  $arg: $val"
+    args["mpi"] && MPI.Init()
+
+    @onrank 0 begin
+        @info "Parsed args:"
+        for (arg, val) in args
+            @info "  $arg: $val"
+        end
     end
 
     architecture = args["cpu"] ? CPU() : GPU()
+
+    if args["mpi"]
+        architecture = Distributed(architecture)
+    end
 
     output_interval = args["output-interval-days"] * 1day
 
@@ -65,9 +85,15 @@ function main()
         northern_basin_surface_evaporation=args["northern-basin-surface-evaporation"],
         sill_height=args["sill-height"],
         use_eddy_closure=args["use-eddy-closure"],
+        split_explicit_free_surface_substeps=args["free-surface-substeps"],
     )
 
     mask = GyreInABox.northern_basin_mask(parameters)
+
+    timestamp = format(now(), "yyyy-mm-dd_HH-MM-SS")
+
+    run_directory = joinpath(args["output-directory"], "$timestamp-run")
+    @onrank 0 mkdir(run_directory)
 
     configuration = SimulationConfiguration(
         architecture=architecture,
@@ -76,7 +102,7 @@ function main()
         maximum_timestep=60minute,
         wizard_max_change=1.1,
         wizard_update_interval=10,
-        output_filename="spall_2012_gyre_model",
+        output_filename=joinpath(run_directory, "spall_2012_gyre_model"),
         output_types=(
             HorizontalSlice(schedule=TimeInterval(output_interval)),
             HorizontalSlice(depth=parameters.bottom_depth + parameters.sill_height, schedule=TimeInterval(output_interval)),
@@ -92,14 +118,11 @@ function main()
         ),
         progress_message_interval=1000
     )
-    
-    timestamp = format(now(), "yyyy-mm-dd_HH-MM-SS")
 
-    run_directory = mkdir("$timestamp-run")
-    cd(run_directory)
-
-    jldsave("parameters.jld2"; parameters)
-    jldsave("configuration.jld2"; configuration)
+    @onrank 0 begin
+        jldsave(joinpath(run_directory, "parameters.jld2"); parameters)
+        jldsave(joinpath(run_directory, "configuration.jld2"); configuration)
+    end
 
     run_simulation(parameters, configuration)
 

--- a/src/GyreInABox.jl
+++ b/src/GyreInABox.jl
@@ -46,6 +46,7 @@ module GyreInABox
 
 using DocStringExtensions
 using Oceananigans
+using Oceananigans.DistributedComputations
 using Oceananigans.Grids
 using Oceananigans.Units
 using SeawaterPolynomials: TEOS10EquationOfState

--- a/src/models.jl
+++ b/src/models.jl
@@ -75,13 +75,23 @@ Construct tracer advection scheme for ocean gyre model with parameters `paramete
 function tracer_advection end
 
 """
+    $(FUNCTIONNAME)(parameters, grid)
+
+Construct free surface scheme for ocean gyre model with grid `grid` and parameters `parameters`.
+"""
+function free_surface(::AbstractParameters, grid::AbstractGrid)
+    Oceananigans.Models.HydrostaticFreeSurfaceModels.default_free_surface(grid)
+end
+
+"""
 Set up ocean gyre model with parameters `parameters` on grid with architecture `architecture`.
 
 $(SIGNATURES)
 """
 function setup_model(parameters::AbstractParameters; architecture=CPU())
+    grid_ = grid(parameters, architecture)
     HydrostaticFreeSurfaceModel(
-        grid(parameters, architecture);
+        grid_;
         momentum_advection=momentum_advection(parameters),
         tracer_advection=tracer_advection(parameters),
         coriolis=coriolis(parameters),
@@ -90,5 +100,6 @@ function setup_model(parameters::AbstractParameters; architecture=CPU())
         boundary_conditions=boundary_conditions(parameters),
         forcing=forcing(parameters),
         tracers=tracers(parameters),
+        free_surface=free_surface(parameters, grid_),
     )
 end

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -51,7 +51,7 @@ function add_progress_message_callback!(
         ("max(|$(variable)|) = %.2e $(unit(variable))" for variable in keys(fields)), ", "
     )
     message_string_format = Printf.Format(iteration_format_string * variables_format_string)
-    progress_message(sim) = println(
+    progress_message(sim) = @onrank 0 @info(
         Printf.format(
             message_string_format,
             iteration(sim),

--- a/src/spall_2011.jl
+++ b/src/spall_2011.jl
@@ -20,7 +20,7 @@ Real-valued parameters of model controlling initial and boundary conditions.
 
 $(TYPEDFIELDS)
 """
-@kwdef struct Spall2011Parameters{T} <: AbstractParameters{T}
+@kwdef struct Spall2011Parameters{T, S} <: AbstractParameters{T}
     "Grid dimensions in x, y and depth"
     grid_size::NTuple{3,Int} = (200, 400, 20)
     "Dimensions of grid halo region in x, y and depth"
@@ -97,6 +97,10 @@ $(TYPEDFIELDS)
     surface_wind_forcing_ramp_up_timescale::T = 10day
     "Order of WENO advection schemes for momentum and tracers"
     advection_order::Int = 5
+    "Split explicit free surface CFL target if adaptive substepping to be used"
+    split_explicit_free_surface_cfl::T = 0.7
+    "Split explicit free surface number of steps if fixed substepping to be used"
+    split_explicit_free_surface_substeps::S = nothing 
 end
 
 function zonal_surface_wind_stress(x, y, t, parameters::Spall2011Parameters)
@@ -340,6 +344,14 @@ function momentum_advection(parameters::Spall2011Parameters)
 end
 function tracer_advection(parameters::Spall2011Parameters)
     Oceananigans.WENO(; order=parameters.advection_order)
+end
+
+function free_surface(parameters::Spall2011Parameters{<:Any, <:Nothing}, grid::AbstractGrid)
+    SplitExplicitFreeSurface(grid; cfl=parameters.split_explicit_free_surface_cfl)
+end
+
+function free_surface(parameters::Spall2011Parameters{<:Any, <:Integer}, grid::AbstractGrid)
+    SplitExplicitFreeSurface(grid; substeps=parameters.split_explicit_free_surface_substeps)
 end
 
 function initialize!(model::Oceananigans.AbstractModel, parameters::Spall2011Parameters)


### PR DESCRIPTION
Adds support for distributing computations (using domain decomposition) with MPI when running `scripts/spall_2012.jl` script.

As adaptive substepping of free surface is not supported on distributed grids, this additionally exposes functions and parameters to allow using a fixed number of substeps.

Command line arguments to the script are also added for indicating to use MPI (`--mpi`), specify the number of ranks used in partitioning along x dimension (`--ranks-along-x`), number of free surface substeps (`--free-surface-substeps`) and an option to specify output directory for simulation outputs explicitly (`--output-directory`).