### PR TITLE
Remove rank-restriction in progress callback causing MPI deadlock

### DIFF
--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -51,7 +51,7 @@ function add_progress_message_callback!(
         ("max(|$(variable)|) = %.2e $(unit(variable))" for variable in keys(fields)), ", "
     )
     message_string_format = Printf.Format(iteration_format_string * variables_format_string)
-    progress_message(sim) = @onrank 0 @info(
+    progress_message(sim) = @info(
         Printf.format(
             message_string_format,
             iteration(sim),


### PR DESCRIPTION
The changes in #49 included the addition of an `@onrank 0` macro application to the callback used to print progress messages during a simulation, with the intention of avoiding having multiple interleaved equivalent progress messages from different ranks when running distributed simulations using MPI. The use of `@onrank` within a callback however seems to be causing deadlock so this PR just reverts to printing progress messages on all ranks.