### PR TITLE
Add support for checkpointing and restoring simulations

### DIFF
--- a/scripts/spall_2012.jl
+++ b/scripts/spall_2012.jl
@@ -57,6 +57,9 @@ function parse_commandline()
         "--use-eddy-closure"
             help = "Use a dynamic Smagorinsky eddy closure"
             action = :store_true
+        "--pickup-checkpoint", "-P"
+            help = "Path to checkpoint to restore simulation state from at initialisation"
+            arg_type = String
     end
 
     return parse_args(s)
@@ -121,7 +124,8 @@ function main()
             AverageKineticEnergy(region_mask=mask),
             HorizontallyAveragedTracers(region_mask=mask),
         ),
-        progress_message_interval=1000
+        progress_message_interval=1000,
+        pickup_checkpoint=args["pickup-checkpoint"],
     )
 
     @onrank 0 begin

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -12,7 +12,7 @@ temporal discretization and outputs to record.
 
 $(TYPEDFIELDS)
 """
-@kwdef struct SimulationConfiguration{T,A}
+@kwdef struct SimulationConfiguration{T,A,P}
     "Computational architecture to run simulation on"
     architecture::A = Oceananigans.CPU()
     "Time to simulate for / s"
@@ -37,6 +37,8 @@ $(TYPEDFIELDS)
     )
     "Whether to checkpoint simulation at end"
     checkpoint_at_end::Bool = true
+    "Optional path to checkpoint file to pickup initial simulation state from"
+    pickup_checkpoint::P = nothing
 end
 
 """
@@ -109,7 +111,8 @@ function run_simulation(
     model = setup_model(parameters; architecture=configuration.architecture)
     initialize!(model, parameters)
     simulation = setup_simulation(model, configuration)
-    run!(simulation)
+    pickup = !isnothing(configuration.pickup_checkpoint) && configuration.pickup_checkpoint
+    run!(simulation; pickup)
     if configuration.checkpoint_at_end
         Oceananigans.checkpoint(
             simulation; filepath="$(configuration.output_filename)_checkpoint.jld2"

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -35,6 +35,8 @@ $(TYPEDFIELDS)
     output_types::Tuple = (
         HorizontalSlice(), FreeSurfaceFields(), BarotropicStreamFunction()
     )
+    "Whether to checkpoint simulation at end"
+    checkpoint_at_end::Bool = true
 end
 
 """
@@ -108,6 +110,11 @@ function run_simulation(
     initialize!(model, parameters)
     simulation = setup_simulation(model, configuration)
     run!(simulation)
+    if configuration.checkpoint_at_end
+        Oceananigans.checkpoint(
+            simulation; filepath="$(configuration.output_filename)_checkpoint.jld2"
+        )
+    end
 end
 
 """

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -136,11 +136,17 @@ function plot_outputs(
     plot_output_type::AbstractPlotOutput,
     grid::AbstractGrid,
     configuration::SimulationConfiguration;
-    kwargs...
+    kwargs...,
 )
     for output_type in configuration.output_types
         if is_compatible(plot_output_type, output_type)
-            plot_output(plot_output_type, configuration.output_filename, output_type, grid; kwargs...)
+            plot_output(
+                plot_output_type,
+                configuration.output_filename,
+                output_type,
+                grid;
+                kwargs...,
+            )
         end
     end
 end
@@ -149,7 +155,7 @@ function plot_outputs(
     plot_output_type::AbstractPlotOutput,
     parameters::AbstractParameters,
     configuration::SimulationConfiguration;
-    kwargs...
+    kwargs...,
 )
     plot_outputs(plot_output_type, grid(parameters, CPU()), configuration; kwargs...)
 end


### PR DESCRIPTION
Adds options to simulation configuration for storing a checkpoint at end of simulation and optionally restoring simulation initial state from a previous checkpoint, plus corresponding command line argument in the Spall (2012) run script.